### PR TITLE
Create system_calendar

### DIFF
--- a/system_calendar
+++ b/system_calendar
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/NABSA/gbfs/blob/master/gbfs.md#system_calendarjson",
+  "description": "Describes the operating calendar for a system.",
+  "type": "object",
+  "properties": {
+    "last_updated": {
+      "description": "Last time the data in the feed was updated in POSIX time.",
+      "type": "integer",
+      "minimum": 1450155600
+    },
+    "ttl": {
+      "description": "Number of seconds before the data in the feed will be updated again (0 if the data should always be refreshed).",
+      "type": "integer",
+      "minimum": 0
+    },
+    "version": {
+      "description": "GBFS version number to which the feed conforms, according to the versioning framework.",
+      "type": "string",
+      "enum": [
+        "1.0",
+        "1.1-RC",
+        "1.1",
+        "2.0-RC",
+        "2.0",
+        "2.1-RC",
+        "2.1",
+        "3.0-RC",
+        "3.0"
+      ]
+    },
+    "data": {
+      "description": "Array that contains opertions calendar for the system.",
+      "type": "object",
+      "properties": {
+        "calendars": {
+          "type": "array",
+          "items": {
+            "start_month": {
+              "description": "Starting month for the system operations.",
+              "type": "number",
+              "maximum": 1,
+              "minimum": 12
+            },
+            "start_day": {
+              "description": "Starting day for the system operations.",
+              "type": "number",
+              "maximum": 1,
+              "minimum": 31
+            },
+            "start_year": {
+              "description": "Starting year for the system operations.",
+              "type": "number",
+              "pattern": "^\\d{4}$"
+            },
+            "end_month": {
+              "description": "End month for the system operations.",
+              "type": "number",
+              "minimum": 1,
+              "maximum": 12
+            },
+            "end_day": {
+              "description": "End day for the system operations.",
+              "type": "number",
+              "minimum": 1,
+              "maximum": 31
+            },
+            "end_year": {
+              "description": "End year for the system operations.",
+              "type": "number",
+              "pattern": "^\\d{4}$"
+            },
+            "required": [
+              "start_month",
+              "start_day",
+              "end_month",
+              "end_day"
+            ]
+          }
+        }
+      },
+      "required": [
+        "calendars"
+      ]
+    }
+  },
+  "required": [
+    "last_updated",
+    "ttl",
+    "version",
+    "data"
+  ]
+}


### PR DESCRIPTION
For some reason the regex for year wouldn't pass two different validators without using \\, but the regex validator says this is wrong...