### PR TITLE
Use type and properties objects for arrays, tweak required field syntax

### DIFF
--- a/free_bike_status.json
+++ b/free_bike_status.json
@@ -31,72 +31,75 @@
         "bikes": {
           "type": "array",
           "items": {
-            "bike_id": {
-              "description": "Rotating (as of v2.0) identifier of a vehicle.",
-              "type": "string"
-            },
-            "lat": {
-              "description": "The latitude of the vehicle.",
-              "type": "number",
-              "minimum": -90,
-              "maximum": 90
-            },
-            "lon": {
-              "description": "The longitude of the vehicle.",
-              "type": "number",
-              "minimum": -180,
-              "maximum": 180
-            },
-            "is_reserved": {
-              "description": "Is the vehicle currently reserved?",
-              "type": "boolean"
-            },
-            "is_disabled": {
-              "description": "Is the vehicle currently disabled (broken)?",
-              "type": "boolean"
-            },
-            "rental_uris": {
-              "description": "Contains rental uris for Android, iOS, and web in the android, ios, and web fields (added in v1.1).",
-              "type": "object",
-              "properties": {
-                "android": {
-                  "description": "URI that can be passed to an Android app with an intent (added in v1.1).",
-                  "type": "string",
-                  "format": "uri"
-                },
-                "ios": {
-                  "description": "URI that can be used on iOS to launch the rental app for this vehicle (added in v1.1).",
-                  "type": "string",
-                  "format": "uri"
-                },
-                "web": {
-                  "description": "URL that can be used by a web browser to show more information about renting this vehicle (added in v1.1).",
-                  "type": "string",
-                  "format": "uri"
+            "type":"object",
+            "properties": {
+              "bike_id": {
+                "description": "Rotating (as of v2.0) identifier of a vehicle.",
+                "type": "string"
+              },
+              "lat": {
+                "description": "The latitude of the vehicle.",
+                "type": "number",
+                "minimum": -90,
+                "maximum": 90
+              },
+              "lon": {
+                "description": "The longitude of the vehicle.",
+                "type": "number",
+                "minimum": -180,
+                "maximum": 180
+              },
+              "is_reserved": {
+                "description": "Is the vehicle currently reserved?",
+                "type": "boolean"
+              },
+              "is_disabled": {
+                "description": "Is the vehicle currently disabled (broken)?",
+                "type": "boolean"
+              },
+              "rental_uris": {
+                "description": "Contains rental uris for Android, iOS, and web in the android, ios, and web fields (added in v1.1).",
+                "type": "object",
+                "properties": {
+                  "android": {
+                    "description": "URI that can be passed to an Android app with an intent (added in v1.1).",
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "ios": {
+                    "description": "URI that can be used on iOS to launch the rental app for this vehicle (added in v1.1).",
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "web": {
+                    "description": "URL that can be used by a web browser to show more information about renting this vehicle (added in v1.1).",
+                    "type": "string",
+                    "format": "uri"
+                  }
                 }
+              },
+              "vehicle_type_id": {
+                "description": "The vehicle_type_id of this vehicle (added in v2.1-RC).",
+                "type": "string"
+              },
+              "last_reported": {
+                "description": "The last time this vehicle reported its status to the operator's backend in POSIX time (added in v2.1-RC).",
+                "type": "number",
+                "minimum": 1450155600
+              },
+              "current_range_meters": {
+                "description": "The furthest distance in meters that the vehicle can travel without recharging or refueling with the vehicle's current charge or fuel (added in v2.1-RC).",
+                "type": "number",
+                "minimum": 0
+              },
+              "station_id": {
+                "description": "Identifier referencing the station_id if the vehicle is currently at a station (added in v2.1-RC2).",
+                "type": "string"
+              },
+              "pricing_plan_id": {
+                "description": "The plan_id of the pricing plan this vehicle is eligible for (added in v2.1-RC2).",
+                "type": "string"
               }
-            },
-            "vehicle_type_id": {
-              "description": "The vehicle_type_id of this vehicle (added in v2.1-RC).",
-              "type": "string"
-            },
-            "last_reported": {
-              "description": "The last time this vehicle reported its status to the operator's backend in POSIX time (added in v2.1-RC).",
-              "type": "number",
-              "minimum": 1450155600
-            },
-            "current_range_meters": {
-              "description": "The furthest distance in meters that the vehicle can travel without recharging or refueling with the vehicle's current charge or fuel (added in v2.1-RC).",
-              "type": "number",
-              "minimum": 0
-            },
-            "station_id": {
-              "description": "Identifier referencing the station_id if the vehicle is currently at a station (added in v2.1-RC2).",
-              "type": "string"
-            },
-            "pricing_plan_id": {
-              "description": "The plan_id of the pricing plan this vehicle is eligible for (added in v2.1-RC2).",
-              "type": "string"
             },
             "required": [
               "bike_id",
@@ -108,13 +111,13 @@
             "bikes"
           ]
         }
-      },
-      "required": [
-        "last_updated",
-        "ttl",
-        "version",
-        "data"
-      ]
+      }
     }
-  }
+  },
+  "required": [
+    "last_updated",
+    "ttl",
+    "version",
+    "data"
+  ]
 }

--- a/gbfs_versions.json
+++ b/gbfs_versions.json
@@ -63,9 +63,11 @@
               "url"
             ]
           }
-        },
-        "required": true
+        }
       },
+      "required": [
+        "versions"
+      ],
       "additionalProperties": false
     }
   },

--- a/geofencing_zones.json
+++ b/geofencing_zones.json
@@ -32,116 +32,127 @@
         "geofencing_zones": {
           "type": "array",
           "items": {
-            "type": {
-              "description": "FeatureCollection as per IETF RFC 7946.",
-              "type": "string",
-              "enum": [
-                "FeatureCollection"
-              ]
-            },
-            "features": {
-              "description": "Array of objects.",
-              "type": "array",
-              "items": {
-                "title": "GeoJSON Feature",
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "Feature"
-                    ]
-                  },
+            "type": "object",
+            "properties": {
+              "type": {
+                "description": "FeatureCollection as per IETF RFC 7946.",
+                "type": "string",
+                "enum": [
+                  "FeatureCollection"
+                ]
+              },
+              "features": {
+                "description": "Array of objects.",
+                "type": "array",
+                "items": {
+                  "title": "GeoJSON Feature",
+                  "type": "object",
                   "properties": {
-                    "description": "Describing travel allowances and limitations.",
-                    "type": "object",
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "Feature"
+                      ]
+                    },
                     "properties": {
-                      "name": {
-                        "description": "Public name of the geofencing zone.",
-                        "type": "string"
-                      },
-                      "start": {
-                        "description": "Start time of the geofencing zone in POSIX time.",
-                        "type": "number",
-                        "minimum": 1450155600
-                      },
-                      "end": {
-                        "description": "End time of the geofencing zone in POSIX time.",
-                        "type": "number",
-                        "minimum": 1450155600
-                      },
-                      "rules": {
-                        "description": "Array that contains one object per rule.",
-                        "type": "array",
-                        "items": {
-                          "vehicle_type_id": {
-                            "description": "Array of vehicle type IDs for which these restrictions apply.",
-                            "type": "array"
-                          },
-                          "ride_allowed": {
-                            "description": "Is the undocked ride allowed to stat and end in this zone?",
-                            "type": "boolean"
-                          },
-                          "ride_through_allowed": {
-                            "description": "Is the ride allowed to travel through this zone?",
-                            "type": "boolean"
-                          },
-                          "maximum_speed_kph": {
-                            "description": "What is the maximum speed allowed, in kilometers per hour?",
-                            "type": "number",
-                            "minimum": 0
+                      "description": "Describing travel allowances and limitations.",
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "description": "Public name of the geofencing zone.",
+                          "type": "string"
+                        },
+                        "start": {
+                          "description": "Start time of the geofencing zone in POSIX time.",
+                          "type": "number",
+                          "minimum": 1450155600
+                        },
+                        "end": {
+                          "description": "End time of the geofencing zone in POSIX time.",
+                          "type": "number",
+                          "minimum": 1450155600
+                        },
+                        "rules": {
+                          "description": "Array that contains one object per rule.",
+                          "type": "array",
+                          "items": {
+                            "type":"object",
+                            "properties": {
+                              "vehicle_type_id": {
+                                "type": "array",
+                                "description": "Array of vehicle type IDs for which these restrictions apply.",
+                                "items": {"type": "string"}
+                              },
+                              "ride_allowed": {
+                                "description": "Is the undocked ride allowed to stat and end in this zone?",
+                                "type": "boolean"
+                              },
+                              "ride_through_allowed": {
+                                "description": "Is the ride allowed to travel through this zone?",
+                                "type": "boolean"
+                              },
+                              "maximum_speed_kph": {
+                                "description": "What is the maximum speed allowed, in kilometers per hour?",
+                                "type": "number",
+                                "minimum": 0
+                              }
+                            },
+                            "required": [
+                              "ride_allowed",
+                              "ride_through_allowed"
+                            ]
                           }
                         }
                       }
                     },
-                    "required": [
-                      "ride_allowed",
-                      "ride_through_allowed"
-                    ]
-                  },
-                  "geometry": {
-                    "description": "A polygon that describes where rides might not be able to start, end, go through, or have otehr limitations. Must follow the right-hand rule.",
-                    "title": "GeoJSON MultiPolygon",
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "MultiPolygon"
-                        ]
-                      },
-                      "coordinates": {
-                        "type": "array",
-                        "items": {
+                    "geometry": {
+                      "description": "A polygon that describes where rides might not be able to start, end, go through, or have otehr limitations. Must follow the right-hand rule.",
+                      "title": "GeoJSON MultiPolygon",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "MultiPolygon"
+                          ]
+                        },
+                        "coordinates": {
                           "type": "array",
                           "items": {
                             "type": "array",
-                            "minItems": 4,
                             "items": {
                               "type": "array",
-                              "minItems": 2,
+                              "minItems": 4,
                               "items": {
-                                "type": "number"
+                                "type": "array",
+                                "minItems": 2,
+                                "items": {
+                                  "type": "number"
+                                }
                               }
                             }
                           }
                         }
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "coordinates"
-                    ]
-                  }
+                      },
+                      "required": [
+                        "type",
+                        "coordinates"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "geometry",
+                    "properties"
+                  ]
                 }
               }
-            }
-          },
-          "required": [
-            "type",
-            "geometry",
-            "properties"
-          ]
+            },
+            "required": [
+              "type",
+              "features"
+            ]
+          }
         }
       }
     }

--- a/station_information.json
+++ b/station_information.json
@@ -28,152 +28,155 @@
         "stations": {
           "type": "array",
           "items": {
-            "station_id": {
-              "description": "Identifier of a station.",
-              "type": "string"
-            },
-            "name": {
-              "description": "Public name of the station.",
-              "type": "string"
-            },
-            "short_name": {
-              "description": "Short name or other type of identifier.",
-              "type": "string"
-            },
-            "lat": {
-              "description": "The latitude of the station.",
-              "type": "number",
-              "minimum": -90,
-              "maximum": 90
-            },
-            "lon": {
-              "description": "The longitude fo the station.",
-              "type": "number",
-              "minimum": -180,
-              "maximum": 180
-            },
-            "address": {
-              "description": "Address where station is located.",
-              "type": "string"
-            },
-            "cross_street": {
-              "description": "Cross street or landmark where the station is located.",
-              "type": "string"
-            },
-            "region_id": {
-              "description": "Identifier of the region where the station is located.",
-              "type": "string"
-            },
-            "post_code": {
-              "description": "Postal code where station is located.",
-              "type": "string"
-            },
-            "rental_methods": {
-              "description": "Payment methods accepted at this station.",
-              "type": "array",
-              "items": {
-                "type": "string",
-                "enum": [
-                  "key",
-                  "creditcard",
-                  "paypass",
-                  "applepay",
-                  "androidpay",
-                  "transitcard",
-                  "accountnumber",
-                  "phone"
-                ]
+            "type": "object",
+            "properties": {
+              "station_id": {
+                "description": "Identifier of a station.",
+                "type": "string"
               },
-              "minItems": 1
-            },
-            "is_virtual_station": {
-              "description": "Is this station a location with or without physical infrastructure? (added in v2.1-RC)",
-              "type": "boolean"
-            },
-            "station_area": {
-              "description": "A multipolygon that describes the area of a virtual station (added in v2.1-RC).",
-              "type": "object",
-              "required": [
-                "type",
-                "coordinates"
-              ],
-              "properties": {
-                "type": {
+              "name": {
+                "description": "Public name of the station.",
+                "type": "string"
+              },
+              "short_name": {
+                "description": "Short name or other type of identifier.",
+                "type": "string"
+              },
+              "lat": {
+                "description": "The latitude of the station.",
+                "type": "number",
+                "minimum": -90,
+                "maximum": 90
+              },
+              "lon": {
+                "description": "The longitude fo the station.",
+                "type": "number",
+                "minimum": -180,
+                "maximum": 180
+              },
+              "address": {
+                "description": "Address where station is located.",
+                "type": "string"
+              },
+              "cross_street": {
+                "description": "Cross street or landmark where the station is located.",
+                "type": "string"
+              },
+              "region_id": {
+                "description": "Identifier of the region where the station is located.",
+                "type": "string"
+              },
+              "post_code": {
+                "description": "Postal code where station is located.",
+                "type": "string"
+              },
+              "rental_methods": {
+                "description": "Payment methods accepted at this station.",
+                "type": "array",
+                "items": {
                   "type": "string",
                   "enum": [
-                    "Multipolygon"
+                    "key",
+                    "creditcard",
+                    "paypass",
+                    "applepay",
+                    "androidpay",
+                    "transitcard",
+                    "accountnumber",
+                    "phone"
                   ]
                 },
-                "coordinates": {
-                  "type": "array",
-                  "items": {
+                "minItems": 1
+              },
+              "is_virtual_station": {
+                "description": "Is this station a location with or without physical infrastructure? (added in v2.1-RC)",
+                "type": "boolean"
+              },
+              "station_area": {
+                "description": "A multipolygon that describes the area of a virtual station (added in v2.1-RC).",
+                "type": "object",
+                "required": [
+                  "type",
+                  "coordinates"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "Multipolygon"
+                    ]
+                  },
+                  "coordinates": {
                     "type": "array",
                     "items": {
                       "type": "array",
-                      "minItems": 4,
                       "items": {
                         "type": "array",
-                        "minItems": 2,
+                        "minItems": 4,
                         "items": {
-                          "type": "number"
+                          "type": "array",
+                          "minItems": 2,
+                          "items": {
+                            "type": "number"
+                          }
                         }
                       }
                     }
                   }
                 }
-              }
-            },
-            "capacity": {
-              "description": "Number of total docking points installed at this station, both available and unavailable.",
-              "type": "number",
-              "minimum": 0
-            },
-            "vehicle_capacity": {
-              "description": "An object where each key is a vehicle_type_id and the value is a number presenting the total number of vehicles of this type that can park within the station_area (added in v2.1-RC).",
-              "type": "object",
-              "properties": {
-                "type": "number"
-              }
-            },
-            "is_valet_station": {
-              "description": "Are valet services provided at this station? (added in v2.1-RC)",
-              "type": "boolean"
-            },
-            "rental_uris": {
-              "description": "Contains rental uris for Android, iOS, and web in the android, ios, and web fields (added in v1.1).",
-              "type": "object",
-              "properties": {
-                "android": {
-                  "description": "URI that can be passed to an Android app with an intent (added in v1.1).",
-                  "type": "string",
-                  "format": "uri"
-                },
-                "ios": {
-                  "description": "URI that can be used on iOS to launch the rental app for this station (added in v1.1).",
-                  "type": "string",
-                  "format": "uri"
-                },
-                "web": {
-                  "description": "URL that can be used by a web browser to show more information about renting a vehicle at this station (added in v1.1).",
-                  "type": "string",
-                  "format": "uri"
+              },
+              "capacity": {
+                "description": "Number of total docking points installed at this station, both available and unavailable.",
+                "type": "number",
+                "minimum": 0
+              },
+              "vehicle_capacity": {
+                "description": "An object where each key is a vehicle_type_id and the value is a number presenting the total number of vehicles of this type that can park within the station_area (added in v2.1-RC).",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "number"
+                }
+              },
+              "is_valet_station": {
+                "description": "Are valet services provided at this station? (added in v2.1-RC)",
+                "type": "boolean"
+              },
+              "rental_uris": {
+                "description": "Contains rental uris for Android, iOS, and web in the android, ios, and web fields (added in v1.1).",
+                "type": "object",
+                "properties": {
+                  "android": {
+                    "description": "URI that can be passed to an Android app with an intent (added in v1.1).",
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "ios": {
+                    "description": "URI that can be used on iOS to launch the rental app for this station (added in v1.1).",
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "web": {
+                    "description": "URL that can be used by a web browser to show more information about renting a vehicle at this station (added in v1.1).",
+                    "type": "string",
+                    "format": "uri"
+                  }
+                }
+              },
+              "vehicle_type_capacity": {
+                "description": "An object where each key is a vehicle_type_id and the value is a number representing the total docking points installed at this station for each vehicle type (added in v2.1-RC).",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "number"
                 }
               }
             },
-            "vehicle_type_capacity": {
-              "description": "An object where each key is a vehicle_type_id and the value is a number representing the total docking points installed at this station for each vehicle type (added in v2.1-RC).",
-              "type": "object",
-              "additionalProperties": {
-                "type": "number"
-              }
-            }
-          },
-          "required": [
-            "station_id",
-            "name",
-            "lat",
-            "lon"
-          ]
+            "required": [
+              "station_id",
+              "name",
+              "lat",
+              "lon"
+            ]
+          }
         }
       },
       "required": [

--- a/station_status.json
+++ b/station_status.json
@@ -28,118 +28,130 @@
         "stations": {
           "type": "array",
           "items": {
-            "station_id": {
-              "description": "Identifier of a station.",
-              "type": "string"
-            },
-            "num_bikes_available": {
-              "description": "Number of vehicles of any type physically available for rental at the station.",
-              "type": "number",
-              "minimum": 0
-            },
-            "vehicles_types_available": {
-              "description": "Array of objects displaying the total number of each vehicle type at the station (added in v2.1-RC).",
-              "type": "array",
-              "items": {
-                "vehicle_type_id": {
-                  "description": "The vehicle_type_id of vehicle at the station (added in v2.1-RC).",
-                  "type": "string"
-                },
-                "count": {
-                  "description": "A number representing the total amount of this vehicle type at the station (added in v2.1-RC).",
-                  "type": "number",
-                  "minimum": 0
+            "type": "object",
+            "properties": {
+              "station_id": {
+                "description": "Identifier of a station.",
+                "type": "string"
+              },
+              "num_bikes_available": {
+                "description": "Number of vehicles of any type physically available for rental at the station.",
+                "type": "number",
+                "minimum": 0
+              },
+              "vehicles_types_available": {
+                "description": "Array of objects displaying the total number of each vehicle type at the station (added in v2.1-RC).",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "vehicle_type_id": {
+                      "description": "The vehicle_type_id of vehicle at the station (added in v2.1-RC).",
+                      "type": "string"
+                    },
+                    "count": {
+                      "description": "A number representing the total amount of this vehicle type at the station (added in v2.1-RC).",
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  }
                 }
-              }
-            },
-            "num_bikes_disabled": {
-              "description": "Number of disabled vehicles of any type at the station.",
-              "type": "number",
-              "minimum": 0
-            },
-            "num_docks_available": {
-              "description": "Number of functional docks physically at the station.",
-              "type": "number",
-              "minimum": 0
-            },
-            "num_docks_disabled": {
-              "description": "Number of empty but disabled docks at the station.",
-              "type": "number",
-              "minimum": 0
-            },
-            "is_installed": {
-              "description": "Is the station currently on the street?",
-              "type": "boolean"
-            },
-            "is_renting": {
-              "description": "Is the station currently renting vehicles?",
-              "type": "boolean"
-            },
-            "is_returning": {
-              "description": "Is the station accepting vehicle returns?",
-              "type": "boolean"
-            },
-            "last_reported": {
-              "description": "The last time this station reported its status to the operator's backend in POSIX time.",
-              "type": "number",
-              "minimum": 1450155600
-            },
-            "vehicle_docks_available": {
-              "description": "Object displaying available docks by vehicle type (added in v2.1-RC).",
-              "type": "array",
-              "items": {
-                "vehicle_type_ids": {
-                  "description": "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
+              },
+              "num_bikes_disabled": {
+                "description": "Number of disabled vehicles of any type at the station.",
+                "type": "number",
+                "minimum": 0
+              },
+              "num_docks_available": {
+                "description": "Number of functional docks physically at the station.",
+                "type": "number",
+                "minimum": 0
+              },
+              "num_docks_disabled": {
+                "description": "Number of empty but disabled docks at the station.",
+                "type": "number",
+                "minimum": 0
+              },
+              "is_installed": {
+                "description": "Is the station currently on the street?",
+                "type": "boolean"
+              },
+              "is_renting": {
+                "description": "Is the station currently renting vehicles?",
+                "type": "boolean"
+              },
+              "is_returning": {
+                "description": "Is the station accepting vehicle returns?",
+                "type": "boolean"
+              },
+              "last_reported": {
+                "description": "The last time this station reported its status to the operator's backend in POSIX time.",
+                "type": "number",
+                "minimum": 1450155600
+              },
+              "vehicle_docks_available": {
+                "description": "Object displaying available docks by vehicle type (added in v2.1-RC).",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "vehicle_type_ids": {
+                      "description": "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "count": {
+                      "description": "A number representing the total number of available docks for the defined vehicle type (added in v2.1-RC).",
+                      "type": "number",
+                      "minimum": 0
+                    }
                   }
                 },
-                "count": {
-                  "description": "A number representing the total number of available docks for the defined vehicle type (added in v2.1-RC).",
-                  "type": "number",
-                  "minimum": 0
+                "dependencies": {
+                  "vehicle_docks_available": [
+                    "vehicle_type_ids",
+                    "count"
+                  ]
                 }
               },
-              "dependencies": {
-                "vehicle_docks_available": [
-                  "vehicle_type_ids",
-                  "count"
+              "vehicles": {
+                "description": "Array of objects containing data about a specific vehicle that is present at the docking station (added in v2.1-RC).",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "bike_id": {
+                      "description": "Rotated identifier of a vehicle (added in v2.1-RC).",
+                      "type": "string"
+                    },
+                    "is_reserved": {
+                      "description": "Is the vehicle currently reserved for someone else? (added in v2.1-RC)",
+                      "type": "boolean"
+                    },
+                    "is_disabled": {
+                      "description": "Is the vehicle currently disabled (broken)? (added in v2.1-RC)",
+                      "type": "boolean"
+                    },
+                    "vehicle_type_id": {
+                      "description": "The vehicle_type_id of this vehicle as described in vehicle_types.json (added in v2.1-RC).",
+                      "type": "string"
+                    },
+                    "current_range_meters": {
+                      "description": "The furthest distance in meters that the vehicle can travel without recharging or refueling with the vehicle's current charge or fuel (added in v2.1-RC).",
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  }
+                },
+                "required": [
+                  "bike_id",
+                  "is_reserved",
+                  "is_disabled",
+                  "vehicle_type_id"
                 ]
               }
-            },
-            "vehicles": {
-              "description": "Array of objects containing data about a specific vehicle that is present at the docking station (added in v2.1-RC).",
-              "type": "array",
-              "items": {
-                "bike_id": {
-                  "description": "Rotated identifier of a vehicle (added in v2.1-RC).",
-                  "type": "string"
-                },
-                "is_reserved": {
-                  "description": "Is the vehicle currently reserved for someone else? (added in v2.1-RC)",
-                  "type": "boolean"
-                },
-                "is_disabled": {
-                  "description": "Is the vehicle currently disabled (broken)? (added in v2.1-RC)",
-                  "type": "boolean"
-                },
-                "vehicle_type_id": {
-                  "description": "The vehicle_type_id of this vehicle as described in vehicle_types.json (added in v2.1-RC).",
-                  "type": "string"
-                },
-                "current_range_meters": {
-                  "description": "The furthest distance in meters that the vehicle can travel without recharging or refueling with the vehicle's current charge or fuel (added in v2.1-RC).",
-                  "type": "number",
-                  "minimum": 0
-                }
-              },
-              "required": [
-                "bike_id",
-                "is_reserved",
-                "is_disabled",
-                "vehicle_type_id"
-              ]
             }
           },
           "required": [

--- a/system_calendar.json
+++ b/system_calendar.json
@@ -34,39 +34,42 @@
         "calendars": {
           "type": "array",
           "items": {
-            "start_month": {
-              "description": "Starting month for the system operations.",
-              "type": "number",
-              "maximum": 1,
-              "minimum": 12
-            },
-            "start_day": {
-              "description": "Starting day for the system operations.",
-              "type": "number",
-              "maximum": 1,
-              "minimum": 31
-            },
-            "start_year": {
-              "description": "Starting year for the system operations.",
-              "type": "number",
-              "pattern": "^\\d{4}$"
-            },
-            "end_month": {
-              "description": "End month for the system operations.",
-              "type": "number",
-              "minimum": 1,
-              "maximum": 12
-            },
-            "end_day": {
-              "description": "End day for the system operations.",
-              "type": "number",
-              "minimum": 1,
-              "maximum": 31
-            },
-            "end_year": {
-              "description": "End year for the system operations.",
-              "type": "number",
-              "pattern": "^\\d{4}$"
+            "type": "object",
+            "properties": {
+              "start_month": {
+                "description": "Starting month for the system operations.",
+                "type": "number",
+                "maximum": 1,
+                "minimum": 12
+              },
+              "start_day": {
+                "description": "Starting day for the system operations.",
+                "type": "number",
+                "maximum": 1,
+                "minimum": 31
+              },
+              "start_year": {
+                "description": "Starting year for the system operations.",
+                "type": "number",
+                "pattern": "^\\d{4}$"
+              },
+              "end_month": {
+                "description": "End month for the system operations.",
+                "type": "number",
+                "minimum": 1,
+                "maximum": 12
+              },
+              "end_day": {
+                "description": "End day for the system operations.",
+                "type": "number",
+                "minimum": 1,
+                "maximum": 31
+              },
+              "end_year": {
+                "description": "End year for the system operations.",
+                "type": "number",
+                "pattern": "^\\d{4}$"
+              }
             },
             "required": [
               "start_month",

--- a/system_hours.json
+++ b/system_hours.json
@@ -34,46 +34,49 @@
         "rental_hours": {
           "type": "array",
           "items": {
-            "user_types": {
-              "description": "Array of member and nonmember value(s) indicating that this set of rental hours applies to either members or non-members only.",
-              "type": "array",
-              "items": {
-                "type": "string",
-                "enum": [
-                  "member",
-                  "nonmember"
-                ]
+            "type": "object",
+            "properties": {
+              "user_types": {
+                "description": "Array of member and nonmember value(s) indicating that this set of rental hours applies to either members or non-members only.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "member",
+                    "nonmember"
+                  ]
+                },
+                "minItems": 1,
+                "maxItems": 2
               },
-              "minItems": 1,
-              "maxItems": 2
-            },
-            "days": {
-              "description": "An array of abbreviations (first 3 letters) of English names of the days of the week for which this object applies.",
-              "type": "array",
-              "items": {
-                "type": "string",
-                "enum": [
-                  "sun",
-                  "mon",
-                  "tue",
-                  "wed",
-                  "thu",
-                  "fri",
-                  "sat"
-                ]
+              "days": {
+                "description": "An array of abbreviations (first 3 letters) of English names of the days of the week for which this object applies.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "sun",
+                    "mon",
+                    "tue",
+                    "wed",
+                    "thu",
+                    "fri",
+                    "sat"
+                  ]
+                },
+                "minItems": 1,
+                "maxItems": 7
               },
-              "minItems": 1,
-              "maxItems": 7
-            },
-            "start_time": {
-              "description": "Start time for the hours of operation of the system.",
-              "type": "string",
-              "pattern": "^([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$"
-            },
-            "end_time": {
-              "description": "End time for the hours of operation of the system.",
-              "type": "string",
-              "pattern": "^([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$"
+              "start_time": {
+                "description": "Start time for the hours of operation of the system.",
+                "type": "string",
+                "pattern": "^([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$"
+              },
+              "end_time": {
+                "description": "End time for the hours of operation of the system.",
+                "type": "string",
+                "pattern": "^([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$"
+              }
             },
             "required": [
               "user_types",

--- a/system_pricing_plans.json
+++ b/system_pricing_plans.json
@@ -31,104 +31,113 @@
         "plans": {
           "type": "array",
           "items": {
-            "plan_id": {
-              "description": "Identifier of a pricing plan in the system.",
-              "type": "string"
-            },
-            "url": {
-              "description": "URL where the customer can learn more about this pricing plan.",
-              "type": "string",
-              "format": "uri"
-            },
-            "name": {
-              "description": "Name of this pricing plan.",
-              "type": "string"
-            },
-            "currency": {
-              "description": "Currency used to pay the fare in ISO 4217 code.",
-              "type": "string",
-              "pattern": "^\\w{3}$"
-            },
-            "price": {
-              "description": "Fare price.",
-              "type": "number",
-              "minimum": 0
-            },
-            "is_taxable": {
-              "description": "Will additional tax be added to the base price?",
-              "type": "boolean"
-            },
-            "description": {
-              "description": "Customer-readable description of the pricing plan.",
-              "type": "string"
-            },
-            "per_km_pricing": {
-              "description": "Array of segments when the price is a function of distance travelled, displayed in kilometers (added in v2.1-RC2).",
-              "type": "array",
-              "items": {
-                "start": {
-                  "description": "Number of kilometers that have to elapse before this segment starts applying (added in v2.1-RC2).",
-                  "type": "number",
-                  "minimum": 0
-                },
-                "rate": {
-                  "description": "Rate that is charged for each kilometer interval after the start (added in v2.1-RC2).",
-                  "type": "number"
-                },
-                "interval": {
-                  "description": "Interval in kilometers at which the rate of this segment is either reapplied indefinitely, or if defined, up until (but not including) end kilometer (added in v2.1-RC2).",
-                  "type": "number",
-                  "minimum": 0
-                },
-                "end": {
-                  "description": "The kilometer at which the rate will no longer apply (added in v2.1-RC2).",
-                  "type": "number",
-                  "minimum": 0
+            "type": "object",
+            "properties": {
+              "plan_id": {
+                "description": "Identifier of a pricing plan in the system.",
+                "type": "string"
+              },
+              "url": {
+                "description": "URL where the customer can learn more about this pricing plan.",
+                "type": "string",
+                "format": "uri"
+              },
+              "name": {
+                "description": "Name of this pricing plan.",
+                "type": "string"
+              },
+              "currency": {
+                "description": "Currency used to pay the fare in ISO 4217 code.",
+                "type": "string",
+                "pattern": "^\\w{3}$"
+              },
+              "price": {
+                "description": "Fare price.",
+                "type": "number",
+                "minimum": 0
+              },
+              "is_taxable": {
+                "description": "Will additional tax be added to the base price?",
+                "type": "boolean"
+              },
+              "description": {
+                "description": "Customer-readable description of the pricing plan.",
+                "type": "string"
+              },
+              "per_km_pricing": {
+                "description": "Array of segments when the price is a function of distance travelled, displayed in kilometers (added in v2.1-RC2).",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "start": {
+                      "description": "Number of kilometers that have to elapse before this segment starts applying (added in v2.1-RC2).",
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    "rate": {
+                      "description": "Rate that is charged for each kilometer interval after the start (added in v2.1-RC2).",
+                      "type": "number"
+                    },
+                    "interval": {
+                      "description": "Interval in kilometers at which the rate of this segment is either reapplied indefinitely, or if defined, up until (but not including) end kilometer (added in v2.1-RC2).",
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    "end": {
+                      "description": "The kilometer at which the rate will no longer apply (added in v2.1-RC2).",
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  },
+                  "dependencies": {
+                    "per_km_pricing": [
+                      "start",
+                      "rate",
+                      "interval"
+                    ]
+                  }
                 }
               },
-              "dependencies": {
-                "per_km_pricing": [
-                  "start",
-                  "rate",
-                  "interval"
-                ]
-              }
-            },
-            "per_min_pricing": {
-              "description": "Array of segments when the price is a function of time travelled, displayed in minutes (added in v2.1-RC2).",
-              "type": "array",
-              "items": {
-                "start": {
-                  "description": "Number of minutes that have to elapse before this segment starts applying (added in v2.1-RC2).",
-                  "type": "number",
-                  "minimum": 0
-                },
-                "rate": {
-                  "description": "Rate that is charged for each minute interval after the start (added in v2.1-RC2).",
-                  "type": "number"
-                },
-                "interval": {
-                  "description": "Interval in minutes at which the rate of this segment is either reapplied (added in v2.1-RC2).",
-                  "type": "number",
-                  "minimum": "0"
-                },
-                "end": {
-                  "description": "The minute at which the rate will no longer apply (added in v2.1-RC2).",
-                  "type": "number",
-                  "minimum": 0
+              "per_min_pricing": {
+                "description": "Array of segments when the price is a function of time travelled, displayed in minutes (added in v2.1-RC2).",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "start": {
+                      "description": "Number of minutes that have to elapse before this segment starts applying (added in v2.1-RC2).",
+                      "type": "number",
+                      "minimum": 0
+                    },
+                    "rate": {
+                      "description": "Rate that is charged for each minute interval after the start (added in v2.1-RC2).",
+                      "type": "number"
+                    },
+                    "interval": {
+                      "description": "Interval in minutes at which the rate of this segment is either reapplied (added in v2.1-RC2).",
+                      "type": "number",
+                      "minimum": "0"
+                    },
+                    "end": {
+                      "description": "The minute at which the rate will no longer apply (added in v2.1-RC2).",
+                      "type": "number",
+                      "minimum": 0
+                    }
+                  },
+                  "dependencies": {
+                    "per_min_pricing": [
+                      "start",
+                      "rate",
+                      "interval"
+                    ]
+                  }
                 }
               },
-              "dependencies": {
-                "per_min_pricing": [
-                  "start",
-                  "rate",
-                  "interval"
-                ]
+              "surge_pricing": {
+                "description": "Is there currently an increase in price in response to increased demand in this pricing plan? (added in v2.1-RC2)",
+                "type": "boolean"
               }
-            },
-            "surge_pricing": {
-              "description": "Is there currently an increase in price in response to increased demand in this pricing plan? (added in v2.1-RC2)",
-              "type": "boolean"
             }
           },
           "required": [

--- a/system_regions.json
+++ b/system_regions.json
@@ -34,13 +34,16 @@
           "description": "Array of regions.",
           "type": "array",
           "items": {
-            "region_id": {
-              "description": "identifier of the region.",
-              "type": "string"
-            },
-            "name": {
-              "description": "Public name for this region.",
-              "type": "string"
+            "type":"object",
+            "properties": {
+              "region_id": {
+                "description": "identifier of the region.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Public name for this region.",
+                "type": "string"
+              }
             },
             "required": [
               "region_id",

--- a/vehicle_types.json
+++ b/vehicle_types.json
@@ -29,69 +29,72 @@
           "description": "Array that contains one object per vehicle type in the system as defined below.",
           "type": "array",
           "items": {
-            "vehicle_type_id": {
-              "description": "Unique identifier of a vehicle type.",
-              "type": "string"
+            "type": "object",
+            "properties": {
+              "vehicle_type_id": {
+                "description": "Unique identifier of a vehicle type.",
+                "type": "string"
+              },
+              "form_factor": {
+                "description": "The vehicle's general form factor.",
+                "type": "string",
+                "enum": [
+                  "bicycle",
+                  "car",
+                  "moped",
+                  "other",
+                  "scooter"
+                ]
+              },
+              "propulsion_type": {
+                "description": "The primary propulsion type of the vehicle.",
+                "type": "string",
+                "enum": [
+                  "human",
+                  "electric_assist",
+                  "electric",
+                  "combustion"
+                ]
+              },
+              "max_range_meters": {
+                "description": "The furthest distance in meters that the vehicle can travel without recharging or refueling when it has the maximum amount of energy potential.",
+                "type": "number",
+                "minimum": 0
+              },
+              "name": {
+                "description": "The public name of this vehicle type.",
+                "type": "string"
+              }
             },
-            "form_factor": {
-              "description": "The vehicle's general form factor.",
-              "type": "string",
-              "enum": [
-                "bicycle",
-                "car",
-                "moped",
-                "other",
-                "scooter"
-              ]
-            },
-            "propulsion_type": {
-              "description": "The primary propulsion type of the vehicle.",
-              "type": "string",
-              "enum": [
-                "human",
-                "electric_assist",
-                "electric",
-                "combustion"
-              ]
-            },
-            "max_range_meters": {
-              "description": "The furthest distance in meters that the vehicle can travel without recharging or refueling when it has the maximum amount of energy potential.",
-              "type": "number",
-              "minimum": 0
-            },
-            "name": {
-              "description": "The public name of this vehicle type.",
-              "type": "string"
+            "required": [
+              "vehicle_type_id",
+              "form_factor",
+              "propulsion_type"
+            ]
+          },
+          "if": {
+            "properties": {
+              "propulsion_type": {
+                "const": [
+                  "electric",
+                  "electric_assist",
+                  "combustion"
+                ]
+              }
             }
           },
-          "required": [
-            "vehicle_type_id",
-            "form_factor",
-            "propulsion_type"
-          ]
-        },
-        "required": true
-      },
-      "if": {
-        "properties": {
-          "propulsion_type": {
-            "const": [
-              "electric",
-              "electric_assist",
-              "combustion"
-            ]
+          "then": {
+            "properties": {
+              "max_range_meters": {
+                "required": [
+                  "max_range_meters"
+                ]
+              }
+            }
           }
         }
       },
-      "then": {
-        "properties": {
-          "max_range_meters": {
-            "required": [
-              "max_range_meters"
-            ]
-          }
-        }
-      }
+      "required": ["vehicle_types"]
     }
   },
   "required": [


### PR DESCRIPTION
First off, I want to say _thank you_ for this repo. I'm glad I didn't need to roll my own version of these schemas as a starting point for consuming this data 😅.

In this PR, I mostly made two small syntax changes scattered across the schemas:

Many arrays define item properties directly under the `items` key in the containing object. For example:
```js
{
  "type": "array",
  "items":{
    "foo": {...},
    "bar": {...},
  }
}
```
According to [documentation concerning array list validation](https://json-schema.org/understanding-json-schema/reference/array.html#list-validation):

> For [arrays that represent lists], set the items keyword to a single schema that will be used to validate all of the items in the array.

I believe this means we want array items to come in the form:
```js
{
  "type": "array",
  "items":{
    "type": "object",
    "properties": {
      "foo": {...},
      "bar": {...},
    }
  }
}
```

since that's how you'd normally define a schema for an object with certain properties.

Additionally, in some cases, array properties would be marked required by setting `"required": "true"` below the `"items"` property.  

```js
{
  "properties": {
    "foo": {...},
    "required": true
  }
}
```

I'm not sure if that syntax is valid? Again, from the [documentation](https://json-schema.org/understanding-json-schema/reference/object.html#required-properties):
> The required keyword takes an array of zero or more strings. Each of these strings must be unique.

so I also updated instances where that syntax was used to:
```js
{
  "properties": {
    "foo": {...}
  },
  "required": ["foo"]
}
```

The motivation for this PR was that I was hoping to use [quicktype](https://github.com/quicktype/quicktype/) to generate client code for consuming GBFS APIs. Before making these changes, output would be less than ideal. Here's a Python sample from `vehicle_types.json`:
```python
class Data:
    """Response data in the form of name:value pairs."""
    required: Any
    """Array that contains one object per vehicle type in the system as defined below."""
    vehicle_types: Optional[List[Any]]

    def __init__(self, required: Any, vehicle_types: Optional[List[Any]]) -> None:
        self.required = required
        self.vehicle_types = vehicle_types
```
Notice:
- the `required` parameter which shouldn't be there
- `vehicle_types` is interpreted as `Optional[List[Any]]` 

But after these changes:
```python
class Data:
    """Response data in the form of name:value pairs."""
    """Array that contains one object per vehicle type in the system as defined below."""
    vehicle_types: List[VehicleType]

    def __init__(self, vehicle_types: List[VehicleType]) -> None:
        self.vehicle_types = vehicle_types
```
- the `required` keyword is removed
- a `VehicleType` class is generated, with nested classes also generated.

I don't know if the syntax that's modified in this PR is shorthand and that's why `quicktype` is struggling to generate code, but hopefully this actually points to areas of the schemas that can be improved vs faults in the code generation abilities of `quicktype`.