### PR TITLE
Fix `max_range_meters` conditionally required on `vehicle_types.json`

### DIFF
--- a/vehicle_types.json
+++ b/vehicle_types.json
@@ -74,26 +74,16 @@
               "vehicle_type_id",
               "form_factor",
               "propulsion_type"
-            ]
-          },
-          "if": {
-            "properties": {
-              "propulsion_type": {
-                "const": [
-                  "electric",
-                  "electric_assist",
-                  "combustion"
-                ]
+            ],
+            "if": {
+              "properties": {
+                "propulsion_type": {
+                  "enum": ["electric", "electric_assist", "combustion"]
+                }
               }
-            }
-          },
-          "then": {
-            "properties": {
-              "max_range_meters": {
-                "required": [
-                  "max_range_meters"
-                ]
-              }
+            },
+            "then": {
+              "required": ["max_range_meters"]
             }
           }
         }


### PR DESCRIPTION
Hello i got a call with @josee-sabourin yesterday.
She told me it was not possible to validate (set as required) some fields depending of on another field value.

On GBFS spec, it's called "conditionally required" like `max_range_meters` https://github.com/NABSA/gbfs/blob/master/gbfs.md#vehicle_typesjson-added-in-v21
`max_range_meters` must be required when `propulsion_type` is one of `electric` / `electric_assist` / `combustion` value

After checking the current schema, the condition has been described but does not seem to work.
With this update (move condition to a deeper level + remove `propertie` for required + replace `const` per `enum`) it is working as expected.

I can push the update on other fields / schema

Demo: https://runkit.com/embed/hg29sxlhic2r