### PR TITLE
Fix bad spelling of MultiPolygon enum value

### DIFF
--- a/station_information.json
+++ b/station_information.json
@@ -105,7 +105,7 @@
                   "type": {
                     "type": "string",
                     "enum": [
-                      "Multipolygon"
+                      "MultiPolygon"
                     ]
                   },
                   "coordinates": {


### PR DESCRIPTION
GeoJSON has the spelling `MultiPolygon` not `Multipolygon`. It is correctly spelled in geofencing_zones spec.