### PR TITLE
Required fields in system_pricing_plans plan object was incorrectly placed

### DIFF
--- a/system_pricing_plans.json
+++ b/system_pricing_plans.json
@@ -137,16 +137,16 @@
                 "description": "Is there currently an increase in price in response to increased demand in this pricing plan? (added in v2.1-RC2)",
                 "type": "boolean"
               }
-            }
-          },
-          "required": [
-            "plan_id",
-            "name",
-            "currency",
-            "price",
-            "is_taxable",
-            "description"
-          ]
+            },
+            "required": [
+              "plan_id",
+              "name",
+              "currency",
+              "price",
+              "is_taxable",
+              "description"
+            ]
+          }
         }
       },
       "required": [


### PR DESCRIPTION
This error causes validator not to check for required fields on the pricing plan objects.