### PR TITLE
Improved schema

### DIFF
--- a/v1.0/system_information.json
+++ b/v1.0/system_information.json
@@ -51,7 +51,7 @@
         "start_date": {
           "description": 	"Date that the system began operations.",
           "type": "string",
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          "format": "date"
         },
         "phone_number": {
           "description": "A single voice telephone number for the specified system that presents the telephone number as typical for the system's service area.",

--- a/v1.1/system_information.json
+++ b/v1.1/system_information.json
@@ -64,7 +64,7 @@
         "start_date": {
           "description": "Date that the system began operations.",
           "type": "string",
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          "format": "date"
         },
         "phone_number": {
           "description":

--- a/v2.0/system_information.json
+++ b/v2.0/system_information.json
@@ -64,7 +64,7 @@
         "start_date": {
           "description": "Date that the system began operations.",
           "type": "string",
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          "format": "date"
         },
         "phone_number": {
           "description":

--- a/v2.1/free_bike_status.json
+++ b/v2.1/free_bike_status.json
@@ -106,6 +106,24 @@
                 "type": "string"
               }
             },
+            "anyOf": [
+              {
+                "required": ["lat", "lon"],
+                "errorMessage": "Both 'lat' and 'lon' are required."
+              },
+              {
+                "required": ["station_id"],
+                "properties": {
+                  "lat": {
+                    "not": {}
+                  },
+                  "lon": {
+                    "not": {}
+                  }
+                },
+                "errorMessage": "'station_id' is required if 'lat' and 'lon' are not present."
+              }
+            ],
             "required": ["bike_id", "is_reserved", "is_disabled"]
           }
         }

--- a/v2.1/station_status.json
+++ b/v2.1/station_status.json
@@ -47,6 +47,7 @@
                 "description":
                   "Array of objects displaying the total number of each vehicle type at the station (added in v2.1-RC).",
                 "type": "array",
+                "minItems": 1,
                 "items": {
                   "type": "object",
                   "properties": {

--- a/v2.1/system_information.json
+++ b/v2.1/system_information.json
@@ -64,7 +64,7 @@
         "start_date": {
           "description": "Date that the system began operations.",
           "type": "string",
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          "format": "date"
         },
         "phone_number": {
           "description":

--- a/v2.1/vehicle_types.json
+++ b/v2.1/vehicle_types.json
@@ -66,7 +66,8 @@
                 "propulsion_type": {
                   "enum": ["electric", "electric_assist", "combustion"]
                 }
-              }
+              },
+              "required": ["propulsion_type"]
             },
             "then": {
               "required": ["max_range_meters"]

--- a/v2.2/free_bike_status.json
+++ b/v2.2/free_bike_status.json
@@ -111,6 +111,24 @@
                 "type": "string"
               }
             },
+            "anyOf": [
+              {
+                "required": ["lat", "lon"],
+                "errorMessage": "Both 'lat' and 'lon' are required."
+              },
+              {
+                "required": ["station_id"],
+                "properties": {
+                  "lat": {
+                    "not": {}
+                  },
+                  "lon": {
+                    "not": {}
+                  }
+                },
+                "errorMessage": "'station_id' is required if 'lat' and 'lon' are not present."
+              }
+            ],
             "required": ["bike_id", "is_reserved", "is_disabled"]
           }
         }

--- a/v2.2/station_status.json
+++ b/v2.2/station_status.json
@@ -47,6 +47,7 @@
                 "description":
                   "Array of objects displaying the total number of each vehicle type at the station (added in v2.1-RC).",
                 "type": "array",
+                "minItems": 1,
                 "items": {
                   "type": "object",
                   "properties": {

--- a/v2.2/system_information.json
+++ b/v2.2/system_information.json
@@ -64,7 +64,7 @@
         "start_date": {
           "description": "Date that the system began operations.",
           "type": "string",
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          "format": "date"
         },
         "phone_number": {
           "description":

--- a/v2.2/vehicle_types.json
+++ b/v2.2/vehicle_types.json
@@ -66,7 +66,8 @@
                 "propulsion_type": {
                   "enum": ["electric", "electric_assist", "combustion"]
                 }
-              }
+              },
+              "required": ["propulsion_type"]
             },
             "then": {
               "required": ["max_range_meters"]

--- a/v2.3-RC/free_bike_status.json
+++ b/v2.3-RC/free_bike_status.json
@@ -116,6 +116,24 @@
                 "type": "string"
               }
             },
+            "anyOf": [
+              {
+                "required": ["lat", "lon"],
+                "errorMessage": "Both 'lat' and 'lon' are required."
+              },
+              {
+                "required": ["station_id"],
+                "properties": {
+                  "lat": {
+                    "not": {}
+                  },
+                  "lon": {
+                    "not": {}
+                  }
+                },
+                "errorMessage": "'station_id' is required if 'lat' and 'lon' are not present."
+              }
+            ],
             "required": ["bike_id", "is_reserved", "is_disabled"]
           }
         }

--- a/v2.3-RC/station_status.json
+++ b/v2.3-RC/station_status.json
@@ -47,6 +47,7 @@
                 "description":
                   "Array of objects displaying the total number of each vehicle type at the station (added in v2.1-RC).",
                 "type": "array",
+                "minItems": 1,
                 "items": {
                   "type": "object",
                   "properties": {

--- a/v2.3-RC/system_information.json
+++ b/v2.3-RC/system_information.json
@@ -64,7 +64,7 @@
         "start_date": {
           "description": "Date that the system began operations.",
           "type": "string",
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          "format": "date"
         },
         "phone_number": {
           "description":
@@ -101,7 +101,7 @@
             "brand_last_modified": {
               "description": "Date that indicates the last time any included brand assets were updated (added in v2.3-RC).",
               "type": "string",
-              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+              "format": "date"
             },
             "brand_terms_url": {
               "description": "A fully qualified URL pointing to the location of a page that defines the license terms of brand icons, colors or other trademark information (added in v2.3-RC).",
@@ -136,7 +136,7 @@
           "description":
           "The date that the terms of service provided at terms_url were last updated (added in v2.3-RC)",
           "type": "string",
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          "format": "date"
         },
         "privacy_url": {
           "description":
@@ -148,7 +148,7 @@
           "description":
           "The date that the privacy policy provided at privacy_url was last updated (added in v2.3-RC).",
           "type": "string",
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          "format": "date"
         },
         "rental_apps": {
           "description":

--- a/v2.3-RC/system_information.json
+++ b/v2.3-RC/system_information.json
@@ -136,7 +136,7 @@
           "description":
           "The date that the terms of service provided at terms_url were last updated (added in v2.3-RC)",
           "type": "string",
-          "format": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
         },
         "privacy_url": {
           "description":
@@ -148,7 +148,7 @@
           "description":
           "The date that the privacy policy provided at privacy_url was last updated (added in v2.3-RC).",
           "type": "string",
-          "format": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
         },
         "rental_apps": {
           "description":

--- a/v2.3-RC/vehicle_types.json
+++ b/v2.3-RC/vehicle_types.json
@@ -94,20 +94,20 @@
                     "description": "Date that indicates the last time any included vehicle icon images were modified or updated added in v2.3-RC.",
                     "type": "string",
                     "format": "date"
-                  },
-                  "default_pricing_plan_id": {
-                    "description": "A plan_id as defined in system_pricing_plans.json added in v2.3-RC.",
-                    "type": "string"
-                  },
-                  "pricing_plan_ids": {
-                    "description": "Array of all pricing plan IDs as defined in system_pricing_plans.json added in v2.3-RC.",
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
                   }
                 },
                 "required": ["icon_url", "icon_last_modified"]
+              },
+              "default_pricing_plan_id": {
+                "description": "A plan_id as defined in system_pricing_plans.json added in v2.3-RC.",
+                "type": "string"
+              },
+              "pricing_plan_ids": {
+                "description": "Array of all pricing plan IDs as defined in system_pricing_plans.json added in v2.3-RC.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               }
             },
             "required": ["vehicle_type_id", "form_factor", "propulsion_type"],

--- a/v2.3-RC/vehicle_types.json
+++ b/v2.3-RC/vehicle_types.json
@@ -116,7 +116,8 @@
                 "propulsion_type": {
                   "enum": ["electric", "electric_assist", "combustion"]
                 }
-              }
+              },
+              "required": ["propulsion_type"]
             },
             "then": {
               "required": ["max_range_meters"]

--- a/v2.3-RC/vehicle_types.json
+++ b/v2.3-RC/vehicle_types.json
@@ -93,7 +93,7 @@
                   "icon_last_modified": {
                     "description": "Date that indicates the last time any included vehicle icon images were modified or updated added in v2.3-RC.",
                     "type": "string",
-                    "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+                    "format": "date"
                   },
                   "default_pricing_plan_id": {
                     "description": "A plan_id as defined in system_pricing_plans.json added in v2.3-RC.",


### PR DESCRIPTION
- If `max_range_metters` is missing, do not report `propulsion_type` as missing, only `max_range_metters` (`propulsion_type` is now reported missing only when `propulsion_type` is present with a value of "electric", "electric_assist" or "combustion"). In v2.1, v2.2, v2.3-RC
- Vehicles must have `lat` **and** `lon`, or `station_id` (or the three) in v2.1, v2.2, v2.3-RC https://github.com/NABSA/gbfs/blob/master/gbfs.md#vehicle_statusjson
- `vehicle_types_available` : require a non-empty array in v2.1, v2.2, v2.3-RC
- Use `"format": "date"` to check YYYY-MM-DD dates instead of `"pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"` (and fix when `format` were used with a regular expression) https://json-schema.org/understanding-json-schema/reference/string.html#dates-and-times
- `default_pricing_plan_id` and `pricing_plan_ids` are not inside `vehicle_assets` in v2.3-RC https://github.com/NABSA/gbfs/blob/master/gbfs.md#station_informationjson