### PR TITLE
Update V2.3-RC to V2.3-RC2

### DIFF
--- a/v2.3-RC2/free_bike_status.json
+++ b/v2.3-RC2/free_bike_status.json
@@ -59,61 +59,68 @@
                 "type": "boolean"
               },
               "rental_uris": {
-                "description":
-                  "Contains rental uris for Android, iOS, and web in the android, ios, and web fields (added in v1.1).",
+                "description": "Contains rental uris for Android, iOS, and web in the android, ios, and web fields (added in v1.1).",
                 "type": "object",
                 "properties": {
                   "android": {
-                    "description":
-                      "URI that can be passed to an Android app with an intent (added in v1.1).",
+                    "description": "URI that can be passed to an Android app with an intent (added in v1.1).",
                     "type": "string",
                     "format": "uri"
                   },
                   "ios": {
-                    "description":
-                      "URI that can be used on iOS to launch the rental app for this vehicle (added in v1.1).",
+                    "description": "URI that can be used on iOS to launch the rental app for this vehicle (added in v1.1).",
                     "type": "string",
                     "format": "uri"
                   },
                   "web": {
-                    "description":
-                      "URL that can be used by a web browser to show more information about renting this vehicle (added in v1.1).",
+                    "description": "URL that can be used by a web browser to show more information about renting this vehicle (added in v1.1).",
                     "type": "string",
                     "format": "uri"
                   }
                 }
               },
               "vehicle_type_id": {
-                "description":
-                  "The vehicle_type_id of this vehicle (added in v2.1-RC).",
+                "description": "The vehicle_type_id of this vehicle (added in v2.1-RC).",
                 "type": "string"
               },
               "last_reported": {
-                "description":
-                  "The last time this vehicle reported its status to the operator's backend in POSIX time (added in v2.1-RC).",
+                "description": "The last time this vehicle reported its status to the operator's backend in POSIX time (added in v2.1-RC).",
                 "type": "number",
                 "minimum": 1450155600
               },
               "current_range_meters": {
-                "description":
-                  "The furthest distance in meters that the vehicle can travel without recharging or refueling with the vehicle's current charge or fuel (added in v2.1-RC).",
+                "description": "The furthest distance in meters that the vehicle can travel without recharging or refueling with the vehicle's current charge or fuel (added in v2.1-RC).",
+                "type": "number",
+                "minimum": 0
+              },
+              "current_fuel_percent": {
+                "description": "This value represents the current percentage, expressed from 0 to 1, of fuel or battery power remaining in the vehicle. Added in v2.3-RC.",
                 "type": "number",
                 "minimum": 0
               },
               "station_id": {
-                "description":
-                  "Identifier referencing the station_id if the vehicle is currently at a station (added in v2.1-RC2).",
+                "description": "Identifier referencing the station_id if the vehicle is currently at a station (added in v2.1-RC2).",
                 "type": "string"
               },
               "home_station_id": {
-                "description":
-                "The station_id of the station this vehicle must be returned to (added in v2.3-RC).",
+                "description": "The station_id of the station this vehicle must be returned to (added in v2.3-RC).",
                 "type": "string"
               },
               "pricing_plan_id": {
-                "description":
-                  "The plan_id of the pricing plan this vehicle is eligible for (added in v2.1-RC2).",
+                "description": "The plan_id of the pricing plan this vehicle is eligible for (added in v2.2).",
                 "type": "string"
+              },
+              "vehicle_equipment": {
+                "description": "List of vehicle equipment provided by the operator in addition to the accessories already provided in the vehicle. Added in v2.3-RC2.",
+                "type": "array",
+                "items": {
+                  "enum": ["child_seat_a", "child_seat_b", "child_seat_c", "winter_tires", "snow_chains"]
+                }
+              },
+              "available_until": {
+                "description": "The date and time when any rental of the vehicle must be completed. Added in v2.3-RC2.",
+                "type": "string",
+                "pattern": "^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})([A-Z])$"
               }
             },
             "anyOf": [

--- a/v2.3-RC2/free_bike_status.json
+++ b/v2.3-RC2/free_bike_status.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.3-RC/gbfs.md#free_bike_statusjson",
+    "https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md#free_bike_statusjson",
   "description":
     "Describes the vehicles that are available for rent (as of v2.1-RC2).",
   "type": "object",
@@ -22,7 +22,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "2.3-RC"
+      "const": "2.3-RC2"
     },
     "data": {
       "description":

--- a/v2.3-RC2/gbfs.json
+++ b/v2.3-RC2/gbfs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.3-RC/gbfs.md#gbfsjson",
+  "$id": "https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md#gbfsjson",
   "description":
     "Auto-discovery file that links to all of the other files published by the system.",
   "type": "object",
@@ -21,7 +21,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "2.3-RC"
+      "const": "2.3-RC2"
     },
     "data": {
       "description": "Response data in the form of name:value pairs.",

--- a/v2.3-RC2/gbfs_versions.json
+++ b/v2.3-RC2/gbfs_versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.3-RC/gbfs.md#gbfs_versionsjson-added-in-v11",
+    "https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md#gbfs_versionsjson-added-in-v11",
   "description":
     "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",
@@ -22,7 +22,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework.",
       "type": "string",
-      "const": "2.3-RC"
+      "const": "2.3-RC2"
     },
     "data": {
       "description": "Response data in the form of name:value pairs.",

--- a/v2.3-RC2/geofencing_zones.json
+++ b/v2.3-RC2/geofencing_zones.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.3-RC/gbfs.md#geofencing_zonesjson",
+    "https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md#geofencing_zonesjson",
   "description":
     "Describes geofencing zones and their associated rules and attributes (added in v2.1-RC).",
   "type": "object",
@@ -22,7 +22,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework.",
       "type": "string",
-      "const": "2.3-RC"
+      "const": "2.3-RC2"
     },
     "data": {
       "description":

--- a/v2.3-RC2/geofencing_zones.json
+++ b/v2.3-RC2/geofencing_zones.json
@@ -13,26 +13,22 @@
       "minimum": 1450155600
     },
     "ttl": {
-      "description":
-        "Number of seconds before the data in the feed will be updated again (0 if the data should always be refreshed).",
+      "description": "Number of seconds before the data in the feed will be updated again (0 if the data should always be refreshed).",
       "type": "integer",
       "minimum": 0
     },
     "version": {
-      "description":
-        "GBFS version number to which the feed conforms, according to the versioning framework.",
+      "description": "GBFS version number to which the feed conforms, according to the versioning framework.",
       "type": "string",
       "const": "2.3-RC2"
     },
     "data": {
-      "description":
-        "Array that contains geofencing information for the system.",
+      "description": "Array that contains geofencing information for the system.",
       "type": "object",
       "properties": {
         "geofencing_zones": {
           "type": "object",
-          "description":
-            "Each geofenced zone and its associated rules and attributes is described as an object within the array of features.",
+          "description": "Each geofenced zone and its associated rules and attributes is described as an object within the array of features.",
           "properties": {
             "type": {
               "description": "FeatureCollection as per IETF RFC 7946.",
@@ -60,33 +56,28 @@
                         "type": "string"
                       },
                       "start": {
-                        "description":
-                          "Start time of the geofencing zone in POSIX time.",
+                        "description": "Start time of the geofencing zone in POSIX time.",
                         "type": "number",
                         "minimum": 1450155600
                       },
                       "end": {
-                        "description":
-                          "End time of the geofencing zone in POSIX time.",
+                        "description": "End time of the geofencing zone in POSIX time.",
                         "type": "number",
                         "minimum": 1450155600
                       },
                       "rules": {
-                        "description":
-                          "Array that contains one object per rule.",
+                        "description": "Array that contains one object per rule.",
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
                             "vehicle_type_id": {
                               "type": "array",
-                              "description":
-                                "Array of vehicle type IDs for which these restrictions apply.",
+                              "description": "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }
                             },
                             "ride_allowed": {
-                              "description":
-                                "Is the undocked ride allowed to stat and end in this zone?",
+                              "description": "Is the undocked ride allowed to stat and end in this zone?",
                               "type": "boolean"
                             },
                             "ride_through_allowed": {
@@ -95,10 +86,13 @@
                               "type": "boolean"
                             },
                             "maximum_speed_kph": {
-                              "description":
-                                "What is the maximum speed allowed, in kilometers per hour?",
+                              "description": "What is the maximum speed allowed, in kilometers per hour?",
                               "type": "integer",
                               "minimum": 0
+                            },
+                            "station_parking": {
+                              "description": "Vehicle MUST be parked at stations defined in station_information.json within this geofence zone",
+                              "type": "boolean",
                             }
                           },
                           "required": ["ride_allowed", "ride_through_allowed"]

--- a/v2.3-RC2/geofencing_zones.json
+++ b/v2.3-RC2/geofencing_zones.json
@@ -92,7 +92,7 @@
                             },
                             "station_parking": {
                               "description": "Vehicle MUST be parked at stations defined in station_information.json within this geofence zone",
-                              "type": "boolean",
+                              "type": "boolean"
                             }
                           },
                           "required": ["ride_allowed", "ride_through_allowed"]

--- a/v2.3-RC2/station_information.json
+++ b/v2.3-RC2/station_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.3-RC/gbfs.md#station_informationjson",
+    "https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md#station_informationjson",
   "description":
     "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",
@@ -22,7 +22,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "2.3-RC"
+      "const": "2.3-RC2"
     },
     "data": {
       "description":

--- a/v2.3-RC2/station_information.json
+++ b/v2.3-RC2/station_information.json
@@ -145,7 +145,7 @@
               },
               "contact_phone": {
                 "description": "Contact phone of the station. Added in v2.3-RC2",
-                "type": "string",
+                "type": "string"
               },
               "capacity": {
                 "description":

--- a/v2.3-RC2/station_information.json
+++ b/v2.3-RC2/station_information.json
@@ -128,6 +128,26 @@
                   }
                 }
               },
+              "parking_type": {
+                "description": "Type of parking station. Added in v2.3-RC2",
+                  "type": "string",
+                  "enum": [
+                    "parking_lot",
+                    "street_parking",
+                    "underground_parking",
+                    "sidewalk_parking",
+                    "other"
+                  ]
+                },
+              "parking_hoop": {
+                "description": "Are parking hoops present at this station? Added in v2.3-RC2",
+                "type": "boolean"
+              },
+              "contact_phone": {
+                "description": "Contact phone of the station. Added in v2.3-RC2",
+                "type": "string",
+                "pattern": "^\\+[1-9]\\d{1,14}$"
+              },
               "capacity": {
                 "description":
                   "Number of total docking points installed at this station, both available and unavailable.",

--- a/v2.3-RC2/station_information.json
+++ b/v2.3-RC2/station_information.json
@@ -146,7 +146,6 @@
               "contact_phone": {
                 "description": "Contact phone of the station. Added in v2.3-RC2",
                 "type": "string",
-                "pattern": "^\\+[1-9]\\d{1,14}$"
               },
               "capacity": {
                 "description":

--- a/v2.3-RC2/station_status.json
+++ b/v2.3-RC2/station_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.3-RC/gbfs.md#station_statusjson",
+  "$id": "https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md#station_statusjson",
   "description":
     "Describes the capacity and rental availability of the station",
   "type": "object",
@@ -21,7 +21,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "2.3-RC"
+      "const": "2.3-RC2"
     },
     "data": {
       "description":

--- a/v2.3-RC2/system_alerts.json
+++ b/v2.3-RC2/system_alerts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.3-RC/gbfs.md#system_alertsjson",
+  "$id": "https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md#system_alertsjson",
   "description": "Describes ad-hoc changes to the system.",
   "type": "object",
   "properties": {
@@ -20,7 +20,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "2.3-RC"
+      "const": "2.3-RC2"
     },
     "data": {
       "description": "Array that contains ad-hoc alerts for the system.",

--- a/v2.3-RC2/system_calendar.json
+++ b/v2.3-RC2/system_calendar.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.3-RC/gbfs.md#system_calendarjson",
+    "https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md#system_calendarjson",
   "description": "Describes the operating calendar for a system.",
   "type": "object",
   "properties": {
@@ -21,7 +21,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "2.3-RC"
+      "const": "2.3-RC2"
     },
     "data": {
       "description": "Array that contains opertions calendar for the system.",

--- a/v2.3-RC2/system_hours.json
+++ b/v2.3-RC2/system_hours.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.3-RC/gbfs.md#system_hoursjson",
+  "$id": "https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md#system_hoursjson",
   "description": "Describes the system hours of operation.",
   "type": "object",
   "properties": {
@@ -20,7 +20,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "2.3-RC"
+      "const": "2.3-RC2"
     },
     "data": {
       "description": "Array that contains system hours of operations.",

--- a/v2.3-RC2/system_information.json
+++ b/v2.3-RC2/system_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.3-RC/gbfs.md#system_informationjson",
+    "https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md#system_informationjson",
   "description":
     "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",
@@ -22,7 +22,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "2.3-RC"
+      "const": "2.3-RC2"
     },
     "data": {
       "description": "Response data in the form of name:value pairs.",

--- a/v2.3-RC2/system_pricing_plans.json
+++ b/v2.3-RC2/system_pricing_plans.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.3-RC/gbfs.md#system_pricing_plansjson",
+    "https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md#system_pricing_plansjson",
   "description": "Describes the pricing schemes of the system.",
   "type": "object",
   "properties": {
@@ -21,7 +21,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "2.3-RC"
+      "const": "2.3-RC2"
     },
     "data": {
       "description":

--- a/v2.3-RC2/system_regions.json
+++ b/v2.3-RC2/system_regions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/NABSA/gbfs/blob/v2.3-RC/gbfs.md#system_regionsjson",
+  "$id": "https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md#system_regionsjson",
   "description":
     "Describes regions for a system that is broken up by geographic or political region.",
   "type": "object",
@@ -21,7 +21,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "2.3-RC"
+      "const": "2.3-RC2"
     },
     "data": {
       "description": "Describe regions for a system that is broken up by geographic or political region.",

--- a/v2.3-RC2/vehicle_types.json
+++ b/v2.3-RC2/vehicle_types.json
@@ -78,7 +78,7 @@
                     },
                     "eco_sticker": {
                       "description": " Name of the eco label. Added in v2.3-RC2.",
-                      "type": "string",
+                      "type": "string"
                     }
                   }
                 },
@@ -92,7 +92,7 @@
               },
               "name": {
                 "description": "The public name of this vehicle type.",
-                "type": "string",
+                "type": "string"
               },
               "vehicle_accessories": {
                 "description": "Description of accessories available in the vehicle.",
@@ -113,15 +113,15 @@
               },
               "make": {
                 "description": "The name of the vehicle manufacturer. Added in v2.3-RC2",
-                "type": "string",
+                "type": "string"
               },
               "model": {
                 "description": "The name of the vehicle model. Added in v2.3-RC2",
-                "type": "string",
+                "type": "string"
               },
               "color": {
                 "description": "The color of the vehicle. Added in v2.3-RC2",
-                "type": "string",
+                "type": "string"
               },
               "wheel_count": {
                 "description": "Number of wheels this vehicle type has. Added in v2.3-RC2",
@@ -146,7 +146,7 @@
               "return_constraint": {
                 "description": "The conditions for returning the vehicle at the end of the trip. Added in v2.3-RC as return_type, and updated to return_constraint in v2.3-RC2.",
                 "type": "string",
-                "enum": ["free_floating", "roundtrip_station", "any_station", "hybrid"],
+                "enum": ["free_floating", "roundtrip_station", "any_station", "hybrid"]
               },
               "vehicle_assets": {
                 "description": "An object where each key defines one of the items listed below added in v2.3-RC.",

--- a/v2.3-RC2/vehicle_types.json
+++ b/v2.3-RC2/vehicle_types.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.3-RC/gbfs.md#vehicle_typesjson-added-in-v21-rc",
+    "https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md#vehicle_typesjson-added-in-v21-rc",
   "description":
     "Describes the types of vehicles that System operator has available for rent (added in v2.1-RC).",
   "type": "object",
@@ -22,7 +22,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework.",
       "type": "string",
-      "const": "2.3-RC"
+      "const": "2.3-RC2"
     },
     "data": {
       "description": "Response data in the form of name:value pairs.",

--- a/v2.3-RC2/vehicle_types.json
+++ b/v2.3-RC2/vehicle_types.json
@@ -1,26 +1,26 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-  "https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md#vehicle_typesjson-added-in-v21-rc",
+    "https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md#vehicle_typesjson-added-in-v21-rc",
   "description":
-  "Describes the types of vehicles that System operator has available for rent (added in v2.1-RC).",
+    "Describes the types of vehicles that System operator has available for rent (added in v2.1-RC).",
   "type": "object",
   "properties": {
     "last_updated": {
       "description":
-      "Last time the data in the feed was updated in POSIX time.",
+        "Last time the data in the feed was updated in POSIX time.",
       "type": "integer",
       "minimum": 1450155600
     },
     "ttl": {
       "description":
-      "Number of seconds before the data in the feed will be updated again (0 if the data should always be refreshed).",
+        "Number of seconds before the data in the feed will be updated again (0 if the data should always be refreshed).",
       "type": "integer",
       "minimum": 0
     },
     "version": {
       "description":
-      "GBFS version number to which the feed conforms, according to the versioning framework.",
+        "GBFS version number to which the feed conforms, according to the versioning framework.",
       "type": "string",
       "const": "2.3-RC2"
     },
@@ -30,7 +30,7 @@
       "properties": {
         "vehicle_types": {
           "description":
-          "Array that contains one object per vehicle type in the system as defined below.",
+            "Array that contains one object per vehicle type in the system as defined below.",
           "type": "array",
           "items": {
             "type": "object",
@@ -42,111 +42,39 @@
               "form_factor": {
                 "description": "The vehicle's general form factor.",
                 "type": "string",
-                "enum": ["bicycle", "cargo_bicycle" ,"car", "moped", "scooter_standing", "scooter_seated", "other", "scooter"]
+                "enum": ["bicycle", "car", "moped", "other", "scooter"]
               },
-              "rider_capacity": {
-                "description": "The number of riders (driver included) the vehicle can legally accommodate",
-                "type": "integer",
-                "minimum": 0
-              },
-              "cargo_volume_capacity": {
-                "description": "Cargo volume available in the vehicle, expressed in liters.",
-                "type": "integer",
-                "minimum": 0
-              },
-              "cargo_load_capacity": {
-                "description": "The capacity of the vehicle cargo space (excluding passengers), expressed in kilograms.",
-                "type": "integer",
-                "minimum": 0
-              },
-
               "propulsion_type": {
-                "description": "The primary propulsion type of the vehicle. Updated in v2.3-RC2 to represent car-sharing",
+                "description": "The primary propulsion type of the vehicle.",
                 "type": "string",
-                "enum": ["human", "electric_assist", "electric", "combustion", "combustion_diesel", "hybrid", "plug_in_hybrid", "hydrogen_fuel_cell"]
-              },
-              "eco_label": {
-                "description": "Vehicle air quality certificate. added in v2.3-RC2.",
-                "type": "array",
-                "items":  {
-                  "type": "object",
-                  "properties": {
-                    "country_code": {
-                      "description": " Country code following the ISO 3166-1 alpha-2 notation. Added in v2.3-RC2.",
-                      "type": "string",
-                      "pattern": "^[A-Z]{2}"
-                    },
-                    "eco_sticker": {
-                      "description": " Name of the eco label. Added in v2.3-RC2.",
-                      "type": "string",
-                    }
-                  }
-                },
-                "required": ["country_code", "eco_sticker"]
+                "enum": ["human", "electric_assist", "electric", "combustion"]
               },
               "max_range_meters": {
                 "description":
-                "The furthest distance in meters that the vehicle can travel without recharging or refueling when it has the maximum amount of energy potential.",
+                  "The furthest distance in meters that the vehicle can travel without recharging or refueling when it has the maximum amount of energy potential.",
                 "type": "number",
                 "minimum": 0
               },
               "name": {
                 "description": "The public name of this vehicle type.",
-                "type": "string",
-              },
-              "vehicle_accessories": {
-                "description": "Description of accessories available in the vehicle.",
-                "type": "array",
-                "items": {
-                  "enum": ["air_conditioning", "automatic", "manual", "convertible", "cruise_control", "doors_2", "doors_3", "doors_4", "doors_5", "navigation"]
-                }
-              },
-              "g_CO2_km": {
-                "description": "Maximum quantity of CO2, in grams, emitted per kilometer, according to the WLTP. Added in v2.3-RC2",
-                "type": "number",
-                "minimum": 0
-              },
-              "vehicle_image": {
-                "description": "URL to an image that would assist the user in identifying the vehicle. JPEG or PNG. Added in v2.3-RC2",
-                "type": "string",
-                "format": "uri"
-              },
-              "make": {
-                "description": "The name of the vehicle manufacturer. Added in v2.3-RC2",
-                "type": "string",
-              },
-              "model": {
-                "description": "The name of the vehicle model. Added in v2.3-RC2",
-                "type": "string",
-              },
-              "color": {
-                "description": "The color of the vehicle. Added in v2.3-RC2",
-                "type": "string",
-              },
-              "wheel_count": {
-                "description": "Number of wheels this vehicle type has. Added in v2.3-RC2",
-                "type": "number",
-                "minimum": 0
-              },
-              "max_permitted_speed": {
-                "description": "The maximum speed in kilometers per hour this vehicle is permitted to reach in accordance with local permit and regulations. Added in v2.3-RC2",
-                "type": "number",
-                "minimum": 0
-              },
-              "rated_power": {
-                "description": "The rated power of the motor for this vehicle type in watts. Added in v2.3-RC2",
-                "type": "number",
-                "minimum": 0
+                "type": "string"
               },
               "default_reserve_time": {
                 "description": "Maximum time in minutes that a vehicle can be reserved before a rental begins added in v2.3-RC.",
                 "type": "integer",
                 "minimum": 0
               },
-              "return_constraint": {
-                "description": "The conditions for returning the vehicle at the end of the trip. Added in v2.3-RC as return_type, and updated to return_constraint in v2.3-RC2.",
-                "type": "string",
-                "enum": ["free_floating", "roundtrip_station", "any_station", "hybrid"],
+              "return_type": {
+                "description": "The conditions for returning the vehicle at the end of the trip added in v2.3-RC.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "free_floating",
+                    "roundtrip_station",
+                    "any_station"
+                  ]
+                }
               },
               "vehicle_assets": {
                 "description": "An object where each key defines one of the items listed below added in v2.3-RC.",
@@ -186,9 +114,10 @@
             "if": {
               "properties": {
                 "propulsion_type": {
-                  "enum": ["electric", "electric_assist", "combustion", "combustion_diesel", "hybrid", "plug_in_hybrid", "hydrogen_fuel_cell"]
+                  "enum": ["electric", "electric_assist", "combustion"]
                 }
-              }
+              },
+              "required": ["propulsion_type"]
             },
             "then": {
               "required": ["max_range_meters"]
@@ -201,4 +130,3 @@
   },
   "required": ["last_updated", "ttl", "version", "data"]
 }
-

--- a/v2.3-RC2/vehicle_types.json
+++ b/v2.3-RC2/vehicle_types.json
@@ -30,7 +30,7 @@
       "properties": {
         "vehicle_types": {
           "description":
-            "Array that contains one object per vehicle type in the system as defined below.",
+          "Array that contains one object per vehicle type in the system as defined below.",
           "type": "array",
           "items": {
             "type": "object",
@@ -42,39 +42,111 @@
               "form_factor": {
                 "description": "The vehicle's general form factor.",
                 "type": "string",
-                "enum": ["bicycle", "car", "moped", "other", "scooter"]
+                "enum": ["bicycle", "cargo_bicycle" ,"car", "moped", "scooter_standing", "scooter_seated", "other", "scooter"]
               },
+              "rider_capacity": {
+                "description": "The number of riders (driver included) the vehicle can legally accommodate",
+                "type": "integer",
+                "minimum": 0
+              },
+              "cargo_volume_capacity": {
+                "description": "Cargo volume available in the vehicle, expressed in liters.",
+                "type": "integer",
+                "minimum": 0
+              },
+              "cargo_load_capacity": {
+                "description": "The capacity of the vehicle cargo space (excluding passengers), expressed in kilograms.",
+                "type": "integer",
+                "minimum": 0
+              },
+
               "propulsion_type": {
-                "description": "The primary propulsion type of the vehicle.",
+                "description": "The primary propulsion type of the vehicle. Updated in v2.3-RC2 to represent car-sharing",
                 "type": "string",
-                "enum": ["human", "electric_assist", "electric", "combustion"]
+                "enum": ["human", "electric_assist", "electric", "combustion", "combustion_diesel", "hybrid", "plug_in_hybrid", "hydrogen_fuel_cell"]
+              },
+              "eco_label": {
+                "description": "Vehicle air quality certificate. added in v2.3-RC2.",
+                "type": "array",
+                "items":  {
+                  "type": "object",
+                  "properties": {
+                    "country_code": {
+                      "description": " Country code following the ISO 3166-1 alpha-2 notation. Added in v2.3-RC2.",
+                      "type": "string",
+                      "pattern": "^[A-Z]{2}"
+                    },
+                    "eco_sticker": {
+                      "description": " Name of the eco label. Added in v2.3-RC2.",
+                      "type": "string",
+                    }
+                  }
+                },
+                "required": ["country_code", "eco_sticker"]
               },
               "max_range_meters": {
                 "description":
-                  "The furthest distance in meters that the vehicle can travel without recharging or refueling when it has the maximum amount of energy potential.",
+                "The furthest distance in meters that the vehicle can travel without recharging or refueling when it has the maximum amount of energy potential.",
                 "type": "number",
                 "minimum": 0
               },
               "name": {
                 "description": "The public name of this vehicle type.",
-                "type": "string"
+                "type": "string",
+              },
+              "vehicle_accessories": {
+                "description": "Description of accessories available in the vehicle.",
+                "type": "array",
+                "items": {
+                  "enum": ["air_conditioning", "automatic", "manual", "convertible", "cruise_control", "doors_2", "doors_3", "doors_4", "doors_5", "navigation"]
+                }
+              },
+              "g_CO2_km": {
+                "description": "Maximum quantity of CO2, in grams, emitted per kilometer, according to the WLTP. Added in v2.3-RC2",
+                "type": "number",
+                "minimum": 0
+              },
+              "vehicle_image": {
+                "description": "URL to an image that would assist the user in identifying the vehicle. JPEG or PNG. Added in v2.3-RC2",
+                "type": "string",
+                "format": "uri"
+              },
+              "make": {
+                "description": "The name of the vehicle manufacturer. Added in v2.3-RC2",
+                "type": "string",
+              },
+              "model": {
+                "description": "The name of the vehicle model. Added in v2.3-RC2",
+                "type": "string",
+              },
+              "color": {
+                "description": "The color of the vehicle. Added in v2.3-RC2",
+                "type": "string",
+              },
+              "wheel_count": {
+                "description": "Number of wheels this vehicle type has. Added in v2.3-RC2",
+                "type": "number",
+                "minimum": 0
+              },
+              "max_permitted_speed": {
+                "description": "The maximum speed in kilometers per hour this vehicle is permitted to reach in accordance with local permit and regulations. Added in v2.3-RC2",
+                "type": "number",
+                "minimum": 0
+              },
+              "rated_power": {
+                "description": "The rated power of the motor for this vehicle type in watts. Added in v2.3-RC2",
+                "type": "number",
+                "minimum": 0
               },
               "default_reserve_time": {
                 "description": "Maximum time in minutes that a vehicle can be reserved before a rental begins added in v2.3-RC.",
                 "type": "integer",
                 "minimum": 0
               },
-              "return_type": {
-                "description": "The conditions for returning the vehicle at the end of the trip added in v2.3-RC.",
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "free_floating",
-                    "roundtrip_station",
-                    "any_station"
-                  ]
-                }
+              "return_constraint": {
+                "description": "The conditions for returning the vehicle at the end of the trip. Added in v2.3-RC as return_type, and updated to return_constraint in v2.3-RC2.",
+                "type": "string",
+                "enum": ["free_floating", "roundtrip_station", "any_station", "hybrid"],
               },
               "vehicle_assets": {
                 "description": "An object where each key defines one of the items listed below added in v2.3-RC.",
@@ -114,10 +186,9 @@
             "if": {
               "properties": {
                 "propulsion_type": {
-                  "enum": ["electric", "electric_assist", "combustion"]
+                  "enum": ["electric", "electric_assist", "combustion", "combustion_diesel", "hybrid", "plug_in_hybrid", "hydrogen_fuel_cell"]
                 }
-              },
-              "required": ["propulsion_type"]
+              }
             },
             "then": {
               "required": ["max_range_meters"]
@@ -130,3 +201,4 @@
   },
   "required": ["last_updated", "ttl", "version", "data"]
 }
+

--- a/v2.3-RC2/vehicle_types.json
+++ b/v2.3-RC2/vehicle_types.json
@@ -1,26 +1,26 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md#vehicle_typesjson-added-in-v21-rc",
+  "https://github.com/NABSA/gbfs/blob/v2.3-RC2/gbfs.md#vehicle_typesjson-added-in-v21-rc",
   "description":
-    "Describes the types of vehicles that System operator has available for rent (added in v2.1-RC).",
+  "Describes the types of vehicles that System operator has available for rent (added in v2.1-RC).",
   "type": "object",
   "properties": {
     "last_updated": {
       "description":
-        "Last time the data in the feed was updated in POSIX time.",
+      "Last time the data in the feed was updated in POSIX time.",
       "type": "integer",
       "minimum": 1450155600
     },
     "ttl": {
       "description":
-        "Number of seconds before the data in the feed will be updated again (0 if the data should always be refreshed).",
+      "Number of seconds before the data in the feed will be updated again (0 if the data should always be refreshed).",
       "type": "integer",
       "minimum": 0
     },
     "version": {
       "description":
-        "GBFS version number to which the feed conforms, according to the versioning framework.",
+      "GBFS version number to which the feed conforms, according to the versioning framework.",
       "type": "string",
       "const": "2.3-RC2"
     },
@@ -30,7 +30,7 @@
       "properties": {
         "vehicle_types": {
           "description":
-            "Array that contains one object per vehicle type in the system as defined below.",
+          "Array that contains one object per vehicle type in the system as defined below.",
           "type": "array",
           "items": {
             "type": "object",
@@ -42,39 +42,111 @@
               "form_factor": {
                 "description": "The vehicle's general form factor.",
                 "type": "string",
-                "enum": ["bicycle", "car", "moped", "other", "scooter"]
+                "enum": ["bicycle", "cargo_bicycle" ,"car", "moped", "scooter_standing", "scooter_seated", "other", "scooter"]
               },
+              "rider_capacity": {
+                "description": "The number of riders (driver included) the vehicle can legally accommodate",
+                "type": "integer",
+                "minimum": 0
+              },
+              "cargo_volume_capacity": {
+                "description": "Cargo volume available in the vehicle, expressed in liters.",
+                "type": "integer",
+                "minimum": 0
+              },
+              "cargo_load_capacity": {
+                "description": "The capacity of the vehicle cargo space (excluding passengers), expressed in kilograms.",
+                "type": "integer",
+                "minimum": 0
+              },
+
               "propulsion_type": {
-                "description": "The primary propulsion type of the vehicle.",
+                "description": "The primary propulsion type of the vehicle. Updated in v2.3-RC2 to represent car-sharing",
                 "type": "string",
-                "enum": ["human", "electric_assist", "electric", "combustion"]
+                "enum": ["human", "electric_assist", "electric", "combustion", "combustion_diesel", "hybrid", "plug_in_hybrid", "hydrogen_fuel_cell"]
+              },
+              "eco_label": {
+                "description": "Vehicle air quality certificate. added in v2.3-RC2.",
+                "type": "array",
+                "items":  {
+                  "type": "object",
+                  "properties": {
+                    "country_code": {
+                      "description": " Country code following the ISO 3166-1 alpha-2 notation. Added in v2.3-RC2.",
+                      "type": "string",
+                      "pattern": "^[A-Z]{2}"
+                    },
+                    "eco_sticker": {
+                      "description": " Name of the eco label. Added in v2.3-RC2.",
+                      "type": "string",
+                    }
+                  }
+                },
+                "required": ["country_code", "eco_sticker"]
               },
               "max_range_meters": {
                 "description":
-                  "The furthest distance in meters that the vehicle can travel without recharging or refueling when it has the maximum amount of energy potential.",
+                "The furthest distance in meters that the vehicle can travel without recharging or refueling when it has the maximum amount of energy potential.",
                 "type": "number",
                 "minimum": 0
               },
               "name": {
                 "description": "The public name of this vehicle type.",
-                "type": "string"
+                "type": "string",
+              },
+              "vehicle_accessories": {
+                "description": "Description of accessories available in the vehicle.",
+                "type": "array",
+                "items": {
+                  "enum": ["air_conditioning", "automatic", "manual", "convertible", "cruise_control", "doors_2", "doors_3", "doors_4", "doors_5", "navigation"]
+                }
+              },
+              "g_CO2_km": {
+                "description": "Maximum quantity of CO2, in grams, emitted per kilometer, according to the WLTP. Added in v2.3-RC2",
+                "type": "number",
+                "minimum": 0
+              },
+              "vehicle_image": {
+                "description": "URL to an image that would assist the user in identifying the vehicle. JPEG or PNG. Added in v2.3-RC2",
+                "type": "string",
+                "format": "uri"
+              },
+              "make": {
+                "description": "The name of the vehicle manufacturer. Added in v2.3-RC2",
+                "type": "string",
+              },
+              "model": {
+                "description": "The name of the vehicle model. Added in v2.3-RC2",
+                "type": "string",
+              },
+              "color": {
+                "description": "The color of the vehicle. Added in v2.3-RC2",
+                "type": "string",
+              },
+              "wheel_count": {
+                "description": "Number of wheels this vehicle type has. Added in v2.3-RC2",
+                "type": "number",
+                "minimum": 0
+              },
+              "max_permitted_speed": {
+                "description": "The maximum speed in kilometers per hour this vehicle is permitted to reach in accordance with local permit and regulations. Added in v2.3-RC2",
+                "type": "number",
+                "minimum": 0
+              },
+              "rated_power": {
+                "description": "The rated power of the motor for this vehicle type in watts. Added in v2.3-RC2",
+                "type": "number",
+                "minimum": 0
               },
               "default_reserve_time": {
                 "description": "Maximum time in minutes that a vehicle can be reserved before a rental begins added in v2.3-RC.",
                 "type": "integer",
                 "minimum": 0
               },
-              "return_type": {
-                "description": "The conditions for returning the vehicle at the end of the trip added in v2.3-RC.",
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "free_floating",
-                    "roundtrip_station",
-                    "any_station"
-                  ]
-                }
+              "return_constraint": {
+                "description": "The conditions for returning the vehicle at the end of the trip. Added in v2.3-RC as return_type, and updated to return_constraint in v2.3-RC2.",
+                "type": "string",
+                "enum": ["free_floating", "roundtrip_station", "any_station", "hybrid"],
               },
               "vehicle_assets": {
                 "description": "An object where each key defines one of the items listed below added in v2.3-RC.",
@@ -114,10 +186,9 @@
             "if": {
               "properties": {
                 "propulsion_type": {
-                  "enum": ["electric", "electric_assist", "combustion"]
+                  "enum": ["electric", "electric_assist", "combustion", "combustion_diesel", "hybrid", "plug_in_hybrid", "hydrogen_fuel_cell"]
                 }
-              },
-              "required": ["propulsion_type"]
+              }
             },
             "then": {
               "required": ["max_range_meters"]
@@ -130,3 +201,4 @@
   },
   "required": ["last_updated", "ttl", "version", "data"]
 }
+


### PR DESCRIPTION
On January 31, 2022, a new version of the V2.3 RC has been created. 
This PR replaces the current V2.3-RC to V2.3-RC2.

The changes are:
- https://github.com/NABSA/gbfs/pull/400
- https://github.com/NABSA/gbfs/pull/370
- https://github.com/NABSA/gbfs/pull/350
- https://github.com/NABSA/gbfs/pull/349
- https://github.com/NABSA/gbfs/pull/386/files (this one does not affect the schema)