### PR TITLE
Fix type from number to integer

### DIFF
--- a/v2.3-RC2/geofencing_zones.json
+++ b/v2.3-RC2/geofencing_zones.json
@@ -57,12 +57,12 @@
                       },
                       "start": {
                         "description": "Start time of the geofencing zone in POSIX time.",
-                        "type": "number",
+                        "type": "integer",
                         "minimum": 1450155600
                       },
                       "end": {
                         "description": "End time of the geofencing zone in POSIX time.",
-                        "type": "number",
+                        "type": "integer",
                         "minimum": 1450155600
                       },
                       "rules": {

--- a/v2.3-RC2/station_status.json
+++ b/v2.3-RC2/station_status.json
@@ -99,7 +99,7 @@
               "last_reported": {
                 "description":
                   "The last time this station reported its status to the operator's backend in POSIX time.",
-                "type": "number",
+                "type": "integer",
                 "minimum": 1450155600
               },
               "vehicle_docks_available": {

--- a/v2.3-RC2/system_alerts.json
+++ b/v2.3-RC2/system_alerts.json
@@ -54,12 +54,12 @@
                   "properties": {
                     "start": {
                       "description": "Start time of the alert.",
-                      "type": "number",
+                      "type": "integer",
                       "minimum": 1450155600
                     },
                     "end": {
                       "description": "End time of the alert.",
-                      "type": "number",
+                      "type": "integer",
                       "minimum": 1450155600
                     }
                   }

--- a/v2.3-RC2/vehicle_types.json
+++ b/v2.3-RC2/vehicle_types.json
@@ -103,7 +103,7 @@
               },
               "g_CO2_km": {
                 "description": "Maximum quantity of CO2, in grams, emitted per kilometer, according to the WLTP. Added in v2.3-RC2",
-                "type": "number",
+                "type": "integer",
                 "minimum": 0
               },
               "vehicle_image": {
@@ -125,17 +125,17 @@
               },
               "wheel_count": {
                 "description": "Number of wheels this vehicle type has. Added in v2.3-RC2",
-                "type": "number",
+                "type": "integer",
                 "minimum": 0
               },
               "max_permitted_speed": {
                 "description": "The maximum speed in kilometers per hour this vehicle is permitted to reach in accordance with local permit and regulations. Added in v2.3-RC2",
-                "type": "number",
+                "type": "integer",
                 "minimum": 0
               },
               "rated_power": {
                 "description": "The rated power of the motor for this vehicle type in watts. Added in v2.3-RC2",
-                "type": "number",
+                "type": "integer",
                 "minimum": 0
               },
               "default_reserve_time": {


### PR DESCRIPTION
Closes https://github.com/MobilityData/gbfs-json-schema/issues/68

This PR fixes the type from **number** to **integer** of the following fields:
- vehicle_types.json
  - g_CO2_km
  - wheel_count
  - max_permittes_speed
  - rated_power
- geofencing_zones.json
  - start (timestamp field)
  - end (timestamp field)
- station_status.json
  - last_reported (timestamp field)
- system_alerts.json
  - start (timestamp field)
  - end (timestamp field)