### PR TITLE
Add v3.0 to v3.0-RC schemas

### DIFF
--- a/v3.0-RC/gbfs.json
+++ b/v3.0-RC/gbfs.json
@@ -21,7 +21,10 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.0-RC"
+      "enum": [
+        "3.0-RC",
+        "3.0"
+      ]
     },
     "data": {
       "properties": {

--- a/v3.0-RC/gbfs_versions.json
+++ b/v3.0-RC/gbfs_versions.json
@@ -24,7 +24,7 @@
       "enum": [
         "3.0-RC",
         "3.0"
-      ],
+      ]
     },
     "data": {
       "description": "Response data in the form of name:value pairs.",

--- a/v3.0-RC/gbfs_versions.json
+++ b/v3.0-RC/gbfs_versions.json
@@ -21,7 +21,10 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework.",
       "type": "string",
-      "const": "3.0-RC"
+      "enum": [
+        "3.0-RC",
+        "3.0"
+      ],
     },
     "data": {
       "description": "Response data in the form of name:value pairs.",

--- a/v3.0-RC/geofencing_zones.json
+++ b/v3.0-RC/geofencing_zones.json
@@ -20,7 +20,10 @@
     "version": {
       "description": "GBFS version number to which the feed conforms, according to the versioning framework.",
       "type": "string",
-      "const": "3.0-RC"
+      "enum": [
+        "3.0-RC",
+        "3.0"
+      ]
     },
     "data": {
       "description": "Array that contains geofencing information for the system.",

--- a/v3.0-RC/manifest.json
+++ b/v3.0-RC/manifest.json
@@ -17,7 +17,10 @@
     "version": {
       "description": "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.0-RC"
+      "enum": [
+        "3.0-RC",
+        "3.0"
+      ]
     },
     "data": {
       "type": "object",

--- a/v3.0-RC/station_information.json
+++ b/v3.0-RC/station_information.json
@@ -22,7 +22,10 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.0-RC"
+      "enum": [
+        "3.0-RC",
+        "3.0"
+      ]
     },
     "data": {
       "description":

--- a/v3.0-RC/station_status.json
+++ b/v3.0-RC/station_status.json
@@ -21,7 +21,10 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.0-RC"
+      "enum": [
+        "3.0-RC",
+        "3.0"
+      ]
     },
     "data": {
       "description":

--- a/v3.0-RC/system_alerts.json
+++ b/v3.0-RC/system_alerts.json
@@ -20,7 +20,10 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.0-RC"
+      "enum": [
+        "3.0-RC",
+        "3.0"
+      ]
     },
     "data": {
       "description": "Array that contains ad-hoc alerts for the system.",

--- a/v3.0-RC/system_information.json
+++ b/v3.0-RC/system_information.json
@@ -22,7 +22,10 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.0-RC"
+      "enum": [
+        "3.0-RC",
+        "3.0"
+      ]
     },
     "data": {
       "description": "Response data in the form of name:value pairs.",

--- a/v3.0-RC/system_pricing_plans.json
+++ b/v3.0-RC/system_pricing_plans.json
@@ -21,7 +21,10 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.0-RC"
+      "enum": [
+        "3.0-RC",
+        "3.0"
+      ]
     },
     "data": {
       "description":

--- a/v3.0-RC/system_regions.json
+++ b/v3.0-RC/system_regions.json
@@ -21,7 +21,10 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.0-RC"
+      "enum": [
+        "3.0-RC",
+        "3.0"
+      ]
     },
     "data": {
       "description": "Describe regions for a system that is broken up by geographic or political region.",

--- a/v3.0-RC/vehicle_status.json
+++ b/v3.0-RC/vehicle_status.json
@@ -22,7 +22,10 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.0-RC"
+      "enum": [
+        "3.0-RC",
+        "3.0"
+      ]
     },
     "data": {
       "description":

--- a/v3.0-RC/vehicle_types.json
+++ b/v3.0-RC/vehicle_types.json
@@ -22,7 +22,10 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework.",
       "type": "string",
-      "const": "3.0-RC"
+      "enum": [
+        "3.0-RC",
+        "3.0"
+      ]
     },
     "data": {
       "description": "Response data in the form of name:value pairs.",


### PR DESCRIPTION
As discussed in the [GBFS slack channel](https://mobilitydata-io.slack.com/archives/CNXA9ASBV/p1686743285808799), we should add the official version enum (3.0) into the RC schema file headers, with a plan to patch the version once official to remove the -RC tag from the file headers.  

Side note: Join the slack channel [here](https://share.mobilitydata.org/slack). 