### PR TITLE
fix: incorrect spec for "languages" property in system_information.json

### DIFF
--- a/v3.0-RC/system_information.json
+++ b/v3.0-RC/system_information.json
@@ -40,7 +40,11 @@
           "description":
             "List of languages used in translated strings. Each element in the list must be of type Language.",
           "type": "array",
-          "pattern": "^[a-z]{2,3}(-[A-Z]{2})?$"
+          "items": {
+            "description": "IETF BCP 47 language code.",
+            "type": "string",
+            "pattern": "^[a-z]{2,3}(-[A-Z]{2})?$"
+          }
         },
         "name": {
           "description": "Name of the system to be displayed to customers. An array with one object per supported language with the following keys:",


### PR DESCRIPTION
The type of the array items must be specified.

Closes #89