### PR TITLE
Replace `required` with boolean (invalid) to array

### DIFF
--- a/v1.0/gbfs.json
+++ b/v1.0/gbfs.json
@@ -40,9 +40,9 @@
             }
           },
           "required": ["feeds"]
-        },
-        "required": true
+        }
       },
+      "minProperties": 1,
       "additionalProperties": false
     }
   },

--- a/v1.1/gbfs.json
+++ b/v1.1/gbfs.json
@@ -63,12 +63,12 @@
                 },
                 "required": ["name", "url"]
               }
-            },
-            "required": true
-          }
-        },
-        "required": true
+            }
+          },
+          "required": ["feeds"]
+        }
       },
+      "minProperties": 1,
       "additionalProperties": false
     }
   },

--- a/v1.1/gbfs_versions.json
+++ b/v1.1/gbfs_versions.json
@@ -58,9 +58,9 @@
             },
             "required": ["version", "url"]
           }
-        },
-        "required": true
+        }
       },
+      "required": ["versions"],
       "additionalProperties": false
     }
   },

--- a/v2.0/gbfs.json
+++ b/v2.0/gbfs.json
@@ -63,12 +63,12 @@
                 },
                 "required": ["name", "url"]
               }
-            },
-            "required": true
-          }
-        },
-        "required": true
+            }
+          },
+          "required": ["feeds"]
+        }
       },
+      "minProperties": 1,
       "additionalProperties": false
     }
   },

--- a/v2.0/gbfs_versions.json
+++ b/v2.0/gbfs_versions.json
@@ -58,9 +58,9 @@
             },
             "required": ["version", "url"]
           }
-        },
-        "required": true
+        }
       },
+      "required": ["versions"],
       "additionalProperties": false
     }
   },

--- a/v2.1/gbfs.json
+++ b/v2.1/gbfs.json
@@ -65,12 +65,12 @@
                 },
                 "required": ["name", "url"]
               }
-            },
-            "required": true
-          }
-        },
-        "required": true
+            }
+          },
+          "required": ["feeds"]
+        }
       },
+      "minProperties": 1,
       "additionalProperties": false
     }
   },

--- a/v2.2/gbfs.json
+++ b/v2.2/gbfs.json
@@ -65,12 +65,12 @@
                 },
                 "required": ["name", "url"]
               }
-            },
-            "required": true
-          }
-        },
-        "required": true
+            }
+          },
+          "required": ["feeds"]
+        }
       },
+      "minProperties": 1,
       "additionalProperties": false
     }
   },

--- a/v2.3/gbfs.json
+++ b/v2.3/gbfs.json
@@ -65,12 +65,12 @@
                 },
                 "required": ["name", "url"]
               }
-            },
-            "required": true
-          }
-        },
-        "required": true
+            }
+          },
+          "required": ["feeds"]
+        }
       },
+      "minProperties": 1,
       "additionalProperties": false
     }
   },

--- a/v3.0-RC/gbfs.json
+++ b/v3.0-RC/gbfs.json
@@ -27,6 +27,7 @@
       ]
     },
     "data": {
+      "type": "object",
       "properties": {
         "feeds": {
           "description": "An array of all of the feeds that are published by the auto-discovery file. Each element in the array is an object with the keys below.",
@@ -59,11 +60,10 @@
             },
             "required": ["name", "url"]
           }
-        },
-        "required": true
-      }
-    },
-    "required": true
+        }
+      },
+      "required": ["feeds"]
+    }
   },
   "additionalProperties": false,
   "required": ["last_updated", "ttl", "version", "data"]

--- a/v3.0-RC/gbfs.json
+++ b/v3.0-RC/gbfs.json
@@ -59,7 +59,8 @@
               }
             },
             "required": ["name", "url"]
-          }
+          },
+          "minItems": 1
         }
       },
       "required": ["feeds"]


### PR DESCRIPTION
This would correct validate https://data-sharing.tier-services.io/tier_paris/gbfs/3.0 as invalid
![image](https://github.com/MobilityData/gbfs-json-schema/assets/1214544/6ffd7e2d-e08a-440e-a28f-480c8d47fac8)

As additional properties are not forbidden, `en` was accepted.
This PR correctly require `feeds` to be required