### PR TITLE
Updates `available_until` regex to allow timezones

### DIFF
--- a/v2.3/free_bike_status.json
+++ b/v2.3/free_bike_status.json
@@ -120,7 +120,7 @@
               "available_until": {
                 "description": "The date and time when any rental of the vehicle must be completed. Added in v2.3.",
                 "type": "string",
-                "pattern": "^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})([A-Z])$"
+                "pattern": "^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})(([+-]([0-9]{2}):([0-9]{2}))|Z)$"
               }
             },
             "anyOf": [

--- a/v3.0-RC/vehicle_status.json
+++ b/v3.0-RC/vehicle_status.json
@@ -123,7 +123,7 @@
               "available_until": {
                 "description": "The date and time when any rental of the vehicle must be completed. Added in v2.3.",
                 "type": "string",
-                "pattern": "^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})([A-Z])$"
+                "pattern": "^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})(([+-]([0-9]{2}):([0-9]{2}))|Z)$"
               }
             },
             "anyOf": [


### PR DESCRIPTION
#### **If you are new to the specification, please introduce yourself (name and organization/link to GBFS). It’s helpful to know who we're chatting with!**  
MobilityData created this Pull Request on behalf of @hbruch.

#### **What problem does your proposal solve? Please begin with the relevant issue number. If there is no existing issue, please also describe alternative solutions you have considered.**
Fixes https://github.com/MobilityData/gbfs-json-schema/issues/95

`available_until` is a Datetime which allows timezones but the regex does not accept timezones.

GBFS [spec](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#field-types) definition:
>Datetime (added in v2.3)- Combination of a date and a time following [ISO 8601 notation](https://www.iso.org/iso-8601-date-and-time-format.html). Attributes : [year](https://docs.python.org/3/library/datetime.html#datetime.datetime.year), [month](https://docs.python.org/3/library/datetime.html#datetime.datetime.month), [day](https://docs.python.org/3/library/datetime.html#datetime.datetime.day), [hour](https://docs.python.org/3/library/datetime.html#datetime.datetime.hour), [minute](https://docs.python.org/3/library/datetime.html#datetime.datetime.minute), [second](https://docs.python.org/3/library/datetime.html#datetime.datetime.second), and timezone.

#### **What is the proposal?**
Update `available_until` regex to allow timezones.

Before | After
-- | --
<img width="898" alt="image" src="https://github.com/MobilityData/gbfs-json-schema/assets/2423604/0f8f00d2-ef90-4a19-8034-aab0b1aa83fb"> | <img width="896" alt="image" src="https://github.com/MobilityData/gbfs-json-schema/assets/2423604/c75258aa-1b50-4022-9ea5-c077a2ababea">

#### **Which files are affected by this change?**
`v2.3/free_bike_status.json` and `v3.0-RC/vehicle_status.json`