### PR TITLE
Revert "Validate uniqueness of values in Arrays of IDs"

### DIFF
--- a/v1.0/system_alerts.json
+++ b/v1.0/system_alerts.json
@@ -60,7 +60,6 @@
               "station_ids": {
                 "description": "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -68,7 +67,6 @@
               "region_ids": {
                 "description": "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/v1.1/system_alerts.json
+++ b/v1.1/system_alerts.json
@@ -71,7 +71,6 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -80,7 +79,6 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/v2.0/system_alerts.json
+++ b/v2.0/system_alerts.json
@@ -71,7 +71,6 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -80,7 +79,6 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/v2.1/geofencing_zones.json
+++ b/v2.1/geofencing_zones.json
@@ -80,7 +80,6 @@
                           "properties": {
                             "vehicle_type_id": {
                               "type": "array",
-                              "uniqueItems": true,
                               "description":
                               "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }

--- a/v2.1/station_status.json
+++ b/v2.1/station_status.json
@@ -112,7 +112,6 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
-                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/v2.1/system_alerts.json
+++ b/v2.1/system_alerts.json
@@ -71,7 +71,6 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -80,7 +79,6 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/v2.2/geofencing_zones.json
+++ b/v2.2/geofencing_zones.json
@@ -80,7 +80,6 @@
                           "properties": {
                             "vehicle_type_id": {
                               "type": "array",
-                              "uniqueItems": true,
                               "description":
                                 "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }

--- a/v2.2/station_status.json
+++ b/v2.2/station_status.json
@@ -112,7 +112,6 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
-                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/v2.2/system_alerts.json
+++ b/v2.2/system_alerts.json
@@ -71,7 +71,6 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -80,7 +79,6 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/v2.3/geofencing_zones.json
+++ b/v2.3/geofencing_zones.json
@@ -73,7 +73,6 @@
                           "properties": {
                             "vehicle_type_id": {
                               "type": "array",
-                              "uniqueItems": true,
                               "description": "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }
                             },

--- a/v2.3/station_status.json
+++ b/v2.3/station_status.json
@@ -112,7 +112,6 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
-                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/v2.3/system_alerts.json
+++ b/v2.3/system_alerts.json
@@ -71,7 +71,6 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -80,7 +79,6 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/v2.3/vehicle_types.json
+++ b/v2.3/vehicle_types.json
@@ -177,7 +177,6 @@
               "pricing_plan_ids": {
                 "description": "Array of all pricing plan IDs as defined in system_pricing_plans.json added in v2.3-RC.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/v3.0-RC/geofencing_zones.json
+++ b/v3.0-RC/geofencing_zones.json
@@ -91,7 +91,6 @@
                           "properties": {
                             "vehicle_type_id": {
                               "type": "array",
-                              "uniqueItems": true,
                               "description": "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }
                             },
@@ -168,7 +167,6 @@
             "properties": {
               "vehicle_type_id": {
                 "type": "array",
-                "uniqueItems": true,
                 "description": "Array of vehicle type IDs for which these restrictions apply.",
                 "items": { "type": "string" }
               },

--- a/v3.0-RC/station_status.json
+++ b/v3.0-RC/station_status.json
@@ -115,7 +115,6 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
-                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/v3.0-RC/system_alerts.json
+++ b/v3.0-RC/system_alerts.json
@@ -74,7 +74,6 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -83,7 +82,6 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/v3.0-RC/vehicle_types.json
+++ b/v3.0-RC/vehicle_types.json
@@ -244,7 +244,6 @@
               "pricing_plan_ids": {
                 "description": "Array of all pricing plan IDs as defined in system_pricing_plans.json added in v2.3-RC.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/v3.0-RC2/geofencing_zones.json
+++ b/v3.0-RC2/geofencing_zones.json
@@ -84,7 +84,6 @@
                           "properties": {
                             "vehicle_type_ids": {
                               "type": "array",
-                              "uniqueItems": true,
                               "description": "Array of vehicle type IDs for which these restrictions apply.",
                               "items": { "type": "string" }
                             },
@@ -163,7 +162,6 @@
             "properties": {
               "vehicle_type_ids": {
                 "type": "array",
-                "uniqueItems": true,
                 "description": "Array of vehicle type IDs for which these restrictions apply.",
                 "items": { "type": "string" }
               },

--- a/v3.0-RC2/station_information.json
+++ b/v3.0-RC2/station_information.json
@@ -200,7 +200,6 @@
                     "vehicle_type_ids": {
                       "description": "The vehicle_type_ids, as defined in vehicle_types.json, that may park at the virtual station.",
                       "type": "array",
-                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }
@@ -223,7 +222,6 @@
                     "vehicle_type_ids": {
                       "description": "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station.",
                       "type": "array",
-                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/v3.0-RC2/station_status.json
+++ b/v3.0-RC2/station_status.json
@@ -116,7 +116,6 @@
                       "description":
                         "An array of strings where each string represents a vehicle_type_id that is able to use a particular type of dock at the station (added in v2.1-RC).",
                       "type": "array",
-                      "uniqueItems": true,
                       "items": {
                         "type": "string"
                       }

--- a/v3.0-RC2/system_alerts.json
+++ b/v3.0-RC2/system_alerts.json
@@ -75,7 +75,6 @@
                 "description":
                   "Array of identifiers of the stations for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }
@@ -84,7 +83,6 @@
                 "description":
                   "Array of identifiers of the regions for which this alert applies.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/v3.0-RC2/vehicle_types.json
+++ b/v3.0-RC2/vehicle_types.json
@@ -245,7 +245,6 @@
               "pricing_plan_ids": {
                 "description": "Array of all pricing plan IDs as defined in system_pricing_plans.json added in v2.3-RC.",
                 "type": "array",
-                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }


### PR DESCRIPTION
Reverts MobilityData/gbfs-json-schema#102

Reverting the validation of unique values in Arrays of IDs since this is a best practice, not explicitly written in the specs.