### PR TITLE
java license to Apache 2.0

### DIFF
--- a/models/java/README.md
+++ b/models/java/README.md
@@ -1,6 +1,6 @@
 # gbfs-java-model
 
-![Maven Central Version](https://img.shields.io/maven-central/v/org.mobilitydata.gbfs/gbfs-java-model.svg)
+![Maven Central Version](https://img.shields.io/maven-central/v/org.mobilitydata/gbfs-java-model.svg)
 
 Generates Java model from GBFS json schema using jsonschema2pojo with jackson2 annotations.
 

--- a/models/java/gbfs-java-model/pom.xml
+++ b/models/java/gbfs-java-model/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mobilitydata</groupId>
     <artifactId>gbfs-java-model</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
 
     <name>gbfs-java-model</name>
 
@@ -17,8 +17,8 @@
     </organization>
     <licenses>
         <license>
-            <name>EUPL-1.2 with modifications</name>
-            <url>https://joinup.ec.europa.eu/software/page/eupl</url>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
           </license>
     </licenses>


### PR DESCRIPTION
Changed the license in the java language bindings from EUPL to Apache to be more consistent with the rest of MobilityData repositories