### PR TITLE
chore: add generateBuilders

### DIFF
--- a/models/java/README.md
+++ b/models/java/README.md
@@ -64,9 +64,7 @@ There is no support in jsonschema2pojo to handle "patternProperties" sanely, it 
 in a class without any properties. The `gbfs.json` feed uses "patternProperties" for the `data`
 property to define an object per language, where the language code is the name of the property.
 
-The generated Gbfs class is therefore extended by
-[src/main/org/entur/gbfs/v2_2/gbfs/GBFS.java](src/main/org/entur/gbfs/v2_2/gbfs/GBFS.java)
-to override the `data` property with a Map implementation. This extended class should be used
+The generated Gbfs class is therefore extended by [gbfs-java-model/src/main/java/org/mobilitydata/gbfs/v2_2/gbfs/GBFS.java](gbfs-java-model/src/main/java/org/mobilitydata/gbfs/v2_2/gbfs/GBFS.java) to override the `data` property with a Map implementation. This extended class should be used
 when unmarshalling the `gbfs.json` feed.
 
 #### station_information.json

--- a/models/java/gbfs-java-model/pom.xml
+++ b/models/java/gbfs-java-model/pom.xml
@@ -210,6 +210,7 @@
                                 <uri>java.lang.String</uri>
                             </formatTypeMapping>
                             <removeOldOutput>false</removeOldOutput>
+                            <generateBuilders>true</generateBuilders>
                             <serializable>true</serializable>
                             <initializeCollections>false</initializeCollections>
                             <generateBuilders>true</generateBuilders>
@@ -229,6 +230,7 @@
                                 <uri>java.lang.String</uri>
                             </formatTypeMapping>
                             <removeOldOutput>false</removeOldOutput>
+                            <generateBuilders>true</generateBuilders>
                             <serializable>true</serializable>
                             <initializeCollections>false</initializeCollections>
                             <generateBuilders>true</generateBuilders>
@@ -248,6 +250,7 @@
                                 <uri>java.lang.String</uri>
                             </formatTypeMapping>
                             <removeOldOutput>false</removeOldOutput>
+                            <generateBuilders>true</generateBuilders>
                             <serializable>true</serializable>
                             <initializeCollections>false</initializeCollections>
                             <generateBuilders>true</generateBuilders>


### PR DESCRIPTION
This PR adds the option `generateBuilders` to jsonschema2pojo since those make the usage of the generated models much more fun. Additionally, a link in the documentation is fixed.