### PR TITLE
Add dependency reservation_price fields mutually exclusive

### DIFF
--- a/v3.1-RC/system_pricing_plans.json
+++ b/v3.1-RC/system_pricing_plans.json
@@ -189,7 +189,11 @@
               "price",
               "is_taxable",
               "description"
-            ]
+            ],
+            "dependencies": {
+              "reservation_price_flat_rate": { "not": { "required": ["reservation_price_per_min"] } },
+              "reservation_price_per_min": { "not": { "required": ["reservation_price_flat_rate"] } }
+            }
           }
         }
       },


### PR DESCRIPTION
## Context
v3.1-RC adds `plans[].reservation_price_per_min` and `plans[].reservation_price_flat_rate`.

The says that the two fields are mutually exclusive ([source](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#system_pricing_plansjson)):
>This field MUST NOT be combined in a single pricing plan with reservation_price_per_min.

## What's Changed
A dependency was added to make `plans[].reservation_price_per_min` and `plans[].reservation_price_flat_rate` mutually exclusive. 

This means that either `reservation_price_flat_rate` OR  `reservation_price_per_min` is present in the same pricing plan but not both of them together.