### PR TITLE
Point implementing class to overridden class

### DIFF
--- a/models/java/gbfs-java-model/pom.xml
+++ b/models/java/gbfs-java-model/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mobilitydata</groupId>
     <artifactId>gbfs-java-model</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
 
     <name>gbfs-java-model</name>
 

--- a/models/java/gbfs-java-model/src/main/java/org/mobilitydata/gbfs/v2_3/gbfs/GBFSFeedName.java
+++ b/models/java/gbfs-java-model/src/main/java/org/mobilitydata/gbfs/v2_3/gbfs/GBFSFeedName.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public enum GBFSFeedName {
-    GBFS("gbfs", GBFSGbfs.class),
+    GBFS("gbfs", org.mobilitydata.gbfs.v2_3.gbfs.GBFS.class),
     GBFSVersions("gbfs_versions", GBFSGbfsVersions.class),
     SystemInformation("system_information", GBFSSystemInformation.class),
     VehicleTypes("vehicle_types", GBFSVehicleTypes.class),


### PR DESCRIPTION
v2 discovery files cannot be deserialized into the generated class, it must use the handwritten class. This was for some reason changed (only in the v2.3 package) when this project was moved into MobilityData space.

See https://github.com/entur/gbfs-java-model/blob/master/gbfs-java-model/src/main/java/org/entur/gbfs/v2_3/gbfs/GBFSFeedName.java#L22