### PR TITLE
Feat/rust cicd

### DIFF
--- a/.github/workflows/rust_crate_publish.yml
+++ b/.github/workflows/rust_crate_publish.yml
@@ -1,0 +1,32 @@
+name: GBFS Rust Language Bindings - Publish
+
+on:
+    push:
+      branches:
+        - master
+      paths:
+        - "models/rust/**"
+jobs:
+    build-publish:
+        name: build-publish-job
+        runs-on: ubuntu-latest
+        defaults:
+          run:
+            working-directory: ./models/rust
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+            
+            - name: Load secrets from 1Password
+              uses: 1password/load-secrets-action@v1.3.1
+              with:
+                export-env: true # Export loaded secrets as environment variables
+              env:
+                CARGO_REGISTRY_TOKEN: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/ms6rxv2lhpok44mg32wuihbv7q/credential"
+    
+            - name: Publish to crates.io
+              env:
+                CARGO_REGISTRY_TOKEN: ${{ env.CARGO_REGISTRY_TOKEN }}
+              run: cargo publish --token $CARGO_REGISTRY_TOKEN
+                

--- a/.github/workflows/rust_pr_check.yml
+++ b/.github/workflows/rust_pr_check.yml
@@ -1,0 +1,79 @@
+name: GBFS Rust Language Bindings - PR Check
+on:
+    pull_request:
+      branches: 
+          - master
+      paths:
+        - "models/rust/**"
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: cargo build --release
+    - run: cargo test --release
+    - run: cargo clippy
+
+  check-versions:
+        name: check-version-job
+        runs-on: ubuntu-latest
+        outputs:
+            has-version-changed: ${{ steps.version-change-check.outputs.VERSION_CHANGED }}
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+            
+            - name: Extract Version from Current Branch
+              id: extract_version_current
+              working-directory: models/rust
+              run: echo "VERSION_CURRENT=$(grep '^version =' Cargo.toml | head -n 1 | awk -F'"' '{print $2}')" >> $GITHUB_OUTPUT
+
+            - name: Checkout master branch
+              run: |
+                git fetch origin master
+                git checkout master
+            
+            - name: Extract Version from Master Branch
+              id: extract_version_master
+              working-directory: models/rust
+              run: echo "VERSION_MASTER=$(grep '^version =' Cargo.toml | head -n 1 | awk -F'"' '{print $2}')" >> $GITHUB_OUTPUT
+            
+            - name: Compare versions
+              id: version-change-check
+              env:
+                local_version: ${{ steps.extract_version_current.outputs.VERSION_CURRENT }}
+                master_version: ${{ steps.extract_version_master.outputs.VERSION_MASTER }}
+              run: |
+                if [ "$local_version" != "$master_version" ]; then
+                    echo "Local branch version ($local_version) is different from master branch version ($master_version)"
+                    echo "VERSION_CHANGED=true" >> $GITHUB_OUTPUT
+                else
+                    echo "Local branch version ($local_version) is the same as master branch version ($master_version)"
+                    echo "Please update the models/rust/Cargo.toml version so that your changes will be published."
+                    echo "VERSION_CHANGED=false" >> $GITHUB_OUTPUT
+                fi
+
+  github-pr-comment:
+        name: pr comment to update pom.xml
+        needs: [check-versions]
+        if: needs.check-versions.outputs.has-version-changed == 'false'
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+            - name: Comment on PR to update pom.xml
+              uses: actions/github-script@v7
+              with:
+                github-token: ${{ secrets.GITHUB_TOKEN }}
+                script: |
+                  github.rest.issues.createComment({
+                    issue_number: context.issue.number,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    body: 'Thank you for opening/editing this pull request. Please update the models/java/gbfs-java-model/pom.xml version so that your changes will be published.'
+                  });
+            - name: Fail the workflow
+              run: exit 1

--- a/models/rust/README.md
+++ b/models/rust/README.md
@@ -28,7 +28,7 @@ use gbfs_types::v3_0::files::SystemInformationFile;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let gbfs_url = "https://data-sharing.tier-services.io/tier_paris/gbfs/3.0/system-information";
+    let gbfs_url = "https://example-gbfs-feed/gbfs/3.0/system-information";
     let client = reqwest::Client::new();
     let response = client.get(url).header("User-Agent", "rust-reqwest").send().await?;
 
@@ -57,12 +57,12 @@ async fn main() -> Result<(), Error> {
         feeds: vec![
             GbfsDataFeeds {
                 name: "system_information".to_string(),
-                url: "https://data-sharing.tier-services.io/tier_paris/gbfs/3.0/system-information".to_string(),
+                url: "https://example-gbfs-feed/gbfs/3.0/system-information".to_string(),
             },
             // ... all other feeds
             GbfsDataFeeds{
                 name: "gbfs_versions".to_string(),
-                url: "https://data-sharing.tier-services.io/tier_paris/gbfs/3.0/versions".to_string()
+                url: "https://example-gbfs-feed/gbfs/3.0/versions".to_string()
             }
         ],
     };


### PR DESCRIPTION
Add the ability to publish Rust crate for `gbfs_types` as well as PR checks. Modified the readme. 
Will fail the publish build if the version in Cargo.toml is not changed