### PR TITLE
update typescript publish with new token

### DIFF
--- a/.github/workflows/typescript_package_publish.yml
+++ b/.github/workflows/typescript_package_publish.yml
@@ -27,7 +27,7 @@ jobs:
                 yarn
 
             - name: Load secrets from 1Password
-              uses: 1password/load-secrets-action@v1.3.1
+              uses: 1password/load-secrets-action@v2.0.0
               with:
                 export-env: true # Export loaded secrets as environment variables
               env:

--- a/.github/workflows/typescript_package_publish.yml
+++ b/.github/workflows/typescript_package_publish.yml
@@ -25,9 +25,17 @@ jobs:
               run: |
                 cd ./scripts
                 yarn
-    
+
+            - name: Load secrets from 1Password
+              uses: 1password/load-secrets-action@v1.3.1
+              with:
+                export-env: true # Export loaded secrets as environment variables
+              env:
+                OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+                NODE_AUTH_TOKEN: "op://TECHNOLOGIES/vwhmodynvelkwrqbpel45ncve4/credential"
+      
             - name: Publish to npm
               run: cd ./models/typescript && npm publish
               env:
-                NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+                NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
                 


### PR DESCRIPTION
As the current npm token to publish the typescript package is set to expire, the new one is set using onepassword