### PR TITLE
Add maximum value of 1 for current_fuel_percent

### DIFF
--- a/v2.3/free_bike_status.json
+++ b/v2.3/free_bike_status.json
@@ -96,7 +96,8 @@
               "current_fuel_percent": {
                 "description": "This value represents the current percentage, expressed from 0 to 1, of fuel or battery power remaining in the vehicle. Added in v2.3-RC.",
                 "type": "number",
-                "minimum": 0
+                "minimum": 0,
+                "maximum": 1
               },
               "station_id": {
                 "description": "Identifier referencing the station_id if the vehicle is currently at a station (added in v2.1-RC2).",

--- a/v3.0/vehicle_status.json
+++ b/v3.0/vehicle_status.json
@@ -96,7 +96,8 @@
               "current_fuel_percent": {
                 "description": "This value represents the current percentage, expressed from 0 to 1, of fuel or battery power remaining in the vehicle. Added in v2.3-RC.",
                 "type": "number",
-                "minimum": 0
+                "minimum": 0,
+                "maximum": 1
               },
               "station_id": {
                 "description": "Identifier referencing the station_id if the vehicle is currently at a station (added in v2.1-RC2).",

--- a/v3.1-RC/vehicle_status.json
+++ b/v3.1-RC/vehicle_status.json
@@ -96,7 +96,8 @@
               "current_fuel_percent": {
                 "description": "This value represents the current percentage, expressed from 0 to 1, of fuel or battery power remaining in the vehicle. Added in v2.3-RC.",
                 "type": "number",
-                "minimum": 0
+                "minimum": 0,
+                "maximum": 1
               },
               "station_id": {
                 "description": "Identifier referencing the station_id if the vehicle is currently at a station (added in v2.1-RC2).",


### PR DESCRIPTION
Fixes https://github.com/MobilityData/gbfs-json-schema/issues/140

## Context
The definition of `vehicles[].current_fuel_percent` in the [spec](https://github.com/MobilityData/gbfs/blob/master/gbfs.md#vehicle_statusjson) is:
>This value represents the current percentage, expressed from 0 to 1, of fuel or battery power remaining in the vehicle.

## Problem
The JSON Schema defines the minium value of 0 but not the maximum value. In consequence, feed providers don't receive appropriate feedback when the value is set to more than 1.

## Solution
This PR adds the maximum value of 1 for `vehicles[].current_fuel_percent` in vehicle_status.json.