### PR TITLE
fix: ability to manually trigger typescript publish

### DIFF
--- a/.github/workflows/typescript_package_publish.yml
+++ b/.github/workflows/typescript_package_publish.yml
@@ -1,6 +1,8 @@
 name: GBFS Typescript Language Bindings - Publish
 
 on:
+    workflow_dispatch:
+    workflow_call:
     push:
       branches:
         - master

--- a/models/typescript/package.json
+++ b/models/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gbfs-typescript-types",
   "version": "1.0.8",
-  "description": "Language Bindings for GBFS in Typescript",
+  "description": "Language Bindings for GBFS in Typescript.",
   "license": "Apache-2.0",
   "types": "index.d.ts",
   "author": "MobilityData",

--- a/models/typescript/package.json
+++ b/models/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gbfs-typescript-types",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Language Bindings for GBFS in Typescript.",
   "license": "Apache-2.0",
   "types": "index.d.ts",


### PR DESCRIPTION
Objective of this PR will be to re-trigger the typescript package build and give the ability to manually trigger it in the future