### PR TITLE
publish gbfs json schemas via npm package

### DIFF
--- a/.github/workflows/schema_package_publish.yml
+++ b/.github/workflows/schema_package_publish.yml
@@ -1,0 +1,37 @@
+name: GBFS Schema - Publish
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    branches:
+      - master
+    paths:
+      - "v*.*/*.json"
+jobs:
+  publish:
+    name: publish-job
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Load secrets from 1Password
+        uses: 1password/load-secrets-action@v2.0.0
+        with:
+          export-env: true # Export loaded secrets as environment variables
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          NODE_AUTH_TOKEN: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/ppzc4jxrwkf3omdmcs7z2wiwum/credential"
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}

--- a/.github/workflows/schema_package_publish.yml
+++ b/.github/workflows/schema_package_publish.yml
@@ -2,7 +2,6 @@ name: GBFS Schema - Publish
 
 on:
   workflow_dispatch:
-  workflow_call:
   push:
     branches:
       - master

--- a/.github/workflows/validate_json.yml
+++ b/.github/workflows/validate_json.yml
@@ -1,5 +1,8 @@
 name: Validate JSON Schema files
-on: [push]
+on:
+  push:
+    paths:
+      - "v*.*/*.json"
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -8,11 +11,11 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: "3.x"
       - name: Install jsonschema
         run: pip install jsonschema==3.2.0
       - run: |
-          for i in **/*.json; do
+          for i in v*.*/*.json; do
             echo "Validating $i"
             jsonschema $i
           done

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "gbfs-json-schema",
+  "version": "1.0.0",
+  "description": "JSON Schemas for GBFS",
+  "license": "Apache-2.0",
+  "author": "MobilityData",
+  "files": [
+    "/v*.*/*.json"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MobilityData/gbfs-json-schema.git"
+  },
+  "bugs": {
+    "url": "https://github.com/MobilityData/gbfs-json-schema/issues"
+  }
+}


### PR DESCRIPTION
We would like to use the gbfs json schemas standalone, i.e. without https://github.com/MobilityData/gbfs-validator. Therefore it would be helpful to have it published as a npm package. This could then also be used in gbfs-validator instead of the git submodule.