### PR TITLE
fix eco_labels required properties

### DIFF
--- a/v2.3/vehicle_types.json
+++ b/v2.3/vehicle_types.json
@@ -80,9 +80,9 @@
                       "description": " Name of the eco label. Added in v2.3.",
                       "type": "string"
                     }
-                  }
-                },
-                "required": ["country_code", "eco_sticker"]
+                  },
+                  "required": ["country_code", "eco_sticker"]
+                }
               },
               "max_range_meters": {
                 "description":

--- a/v3.0/vehicle_types.json
+++ b/v3.0/vehicle_types.json
@@ -80,9 +80,9 @@
                       "description": " Name of the eco label. Added in v2.3.",
                       "type": "string"
                     }
-                  }
-                },
-                "required": ["country_code", "eco_sticker"]
+                  },
+                  "required": ["country_code", "eco_sticker"]
+                }
               },
               "max_range_meters": {
                 "description":

--- a/v3.1-RC/vehicle_types.json
+++ b/v3.1-RC/vehicle_types.json
@@ -80,9 +80,9 @@
                       "description": " Name of the eco label. Added in v2.3.",
                       "type": "string"
                     }
-                  }
-                },
-                "required": ["country_code", "eco_sticker"]
+                  },
+                  "required": ["country_code", "eco_sticker"]
+                }
               },
               "max_range_meters": {
                 "description":


### PR DESCRIPTION
The required field for eco_lables seems to be misplaced in all schemas since it was introduced. 