### PR TITLE
fix schema ids

### DIFF
--- a/v1.0/free_bike_status.json
+++ b/v1.0/free_bike_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#free_bike_statusjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.0/free_bike_status.json",
   "description": "Describes the vehicles that are available for rent (as of v2.1-RC2).",
   "type": "object",
   "properties": {

--- a/v1.0/gbfs.json
+++ b/v1.0/gbfs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#gbfsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.0/gbfs.json",
   "description": "Auto-discovery file that links to all of the other files published by the system.",
   "type": "object",
   "properties": {

--- a/v1.0/station_information.json
+++ b/v1.0/station_information.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#station_informationjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.0/station_information.json",
   "description": "List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.",
   "type": "object",
   "properties": {

--- a/v1.0/station_status.json
+++ b/v1.0/station_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#station_statusjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.0/station_status.json",
   "description": "Describes the capacity and rental availability of the station",
   "type": "object",
   "properties": {

--- a/v1.0/system_alerts.json
+++ b/v1.0/system_alerts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#system_alertsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.0/system_alerts.json",
   "description": 	"Describes ad-hoc changes to the system.",
   "type": "object",
   "properties": {

--- a/v1.0/system_calendar.json
+++ b/v1.0/system_calendar.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#system_calendarjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.0/system_calendar.json",
   "description": "Describes the operating calendar for a system.",
   "type": "object",
   "properties": {

--- a/v1.0/system_hours.json
+++ b/v1.0/system_hours.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#system_hoursjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.0/system_hours.json",
   "description": "Describes the system hours of operation.",
   "type": "object",
   "properties": {

--- a/v1.0/system_information.json
+++ b/v1.0/system_information.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#system_informationjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.0/system_information.json",
   "description": "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",
   "properties": {

--- a/v1.0/system_pricing_plans.json
+++ b/v1.0/system_pricing_plans.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#system_pricing_plansjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.0/system_pricing_plans.json",
   "description": "Describes the pricing schemes of the system.",
   "type": "object",
   "properties": {

--- a/v1.0/system_regions.json
+++ b/v1.0/system_regions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v1.0/gbfs.md#system_regionsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.0/system_regions.json",
   "description": "Describes regions for a system that is broken up by geographic or political region.",
   "type": "object",
   "properties": {

--- a/v1.1/free_bike_status.json
+++ b/v1.1/free_bike_status.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#free_bike_statusjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.1/free_bike_status.json",
   "description":
     "Describes the vehicles that are not at a station and are available for rent.",
   "type": "object",

--- a/v1.1/gbfs.json
+++ b/v1.1/gbfs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#gbfsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.1/gbfs.json",
   "description":
     "Auto-discovery file that links to all of the other files publiished by the system.",
   "type": "object",

--- a/v1.1/gbfs_versions.json
+++ b/v1.1/gbfs_versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.1/gbfs_versions.json-added-in-v11",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.1/gbfs_versions.json",
   "description":
     "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",

--- a/v1.1/gbfs_versions.json
+++ b/v1.1/gbfs_versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#gbfs_versionsjson-added-in-v11",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.1/gbfs_versions.json-added-in-v11",
   "description":
     "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",

--- a/v1.1/station_information.json
+++ b/v1.1/station_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#station_informationjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.1/station_information.json",
   "description":
     "List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.",
   "type": "object",

--- a/v1.1/station_status.json
+++ b/v1.1/station_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#station_statusjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.1/station_status.json",
   "description":
     "Describes the capacity and rental availablility of the station",
   "type": "object",

--- a/v1.1/system_alerts.json
+++ b/v1.1/system_alerts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#system_alertsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.1/system_alerts.json",
   "description": "Describes ad-hoc changes to the system.",
   "type": "object",
   "properties": {

--- a/v1.1/system_calendar.json
+++ b/v1.1/system_calendar.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#system_calendarjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.1/system_calendar.json",
   "description": "Describes the operating calendar for a system.",
   "type": "object",
   "properties": {

--- a/v1.1/system_hours.json
+++ b/v1.1/system_hours.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#system_hoursjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.1/system_hours.json",
   "description": "Describes the system hours of operation.",
   "type": "object",
   "properties": {

--- a/v1.1/system_information.json
+++ b/v1.1/system_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#system_informationjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.1/system_information.json",
   "description":
     "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",

--- a/v1.1/system_pricing_plans.json
+++ b/v1.1/system_pricing_plans.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#system_pricing_plansjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.1/system_pricing_plans.json",
   "description": "Describes the pricing schemes of the system.",
   "type": "object",
   "properties": {

--- a/v1.1/system_regions.json
+++ b/v1.1/system_regions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md#system_regionsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v1.1/system_regions.json",
   "description":
     "Describes regions for a system that is broken up by geographic or political region.",
   "type": "object",

--- a/v2.0/free_bike_status.json
+++ b/v2.0/free_bike_status.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#free_bike_statusjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.0/free_bike_status.json",
   "description":
     "Describes the vehicles that are not at a station and are available for rent.",
   "type": "object",

--- a/v2.0/gbfs.json
+++ b/v2.0/gbfs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#gbfsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.0/gbfs.json",
   "description":
     "Auto-discovery file that links to all of the other files publiished by the system.",
   "type": "object",

--- a/v2.0/gbfs_versions.json
+++ b/v2.0/gbfs_versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#gbfs_versionsjson-added-in-v11",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.0/gbfs_versions.json-added-in-v11",
   "description":
     "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",

--- a/v2.0/gbfs_versions.json
+++ b/v2.0/gbfs_versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.0/gbfs_versions.json-added-in-v11",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.0/gbfs_versions.json",
   "description":
     "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",

--- a/v2.0/station_information.json
+++ b/v2.0/station_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#station_informationjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.0/station_information.json",
   "description":
     "List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.",
   "type": "object",

--- a/v2.0/station_status.json
+++ b/v2.0/station_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#station_statusjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.0/station_status.json",
   "description":
     "Describes the capacity and rental availablility of the station",
   "type": "object",

--- a/v2.0/system_alerts.json
+++ b/v2.0/system_alerts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#system_alertsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.0/system_alerts.json",
   "description": "Describes ad-hoc changes to the system.",
   "type": "object",
   "properties": {

--- a/v2.0/system_calendar.json
+++ b/v2.0/system_calendar.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#system_calendarjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.0/system_calendar.json",
   "description": "Describes the operating calendar for a system.",
   "type": "object",
   "properties": {

--- a/v2.0/system_hours.json
+++ b/v2.0/system_hours.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#system_hoursjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.0/system_hours.json",
   "description": "Describes the system hours of operation.",
   "type": "object",
   "properties": {

--- a/v2.0/system_information.json
+++ b/v2.0/system_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#system_informationjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.0/system_information.json",
   "description":
     "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",

--- a/v2.0/system_pricing_plans.json
+++ b/v2.0/system_pricing_plans.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#system_pricing_plansjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.0/system_pricing_plans.json",
   "description": "Describes the pricing schemes of the system.",
   "type": "object",
   "properties": {

--- a/v2.0/system_regions.json
+++ b/v2.0/system_regions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.0/gbfs.md#system_regionsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.0/system_regions.json",
   "description":
     "Describes regions for a system that is broken up by geographic or political region.",
   "type": "object",

--- a/v2.1/free_bike_status.json
+++ b/v2.1/free_bike_status.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#free_bike_statusjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/free_bike_status.json",
   "description":
     "Describes the vehicles that are available for rent (as of v2.1-RC2).",
   "type": "object",

--- a/v2.1/gbfs.json
+++ b/v2.1/gbfs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#gbfsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/gbfs.json",
   "description":
     "Auto-discovery file that links to all of the other files published by the system.",
   "type": "object",

--- a/v2.1/gbfs_versions.json
+++ b/v2.1/gbfs_versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/gbfs_versions.json-added-in-v11",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/gbfs_versions.json",
   "description":
     "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",

--- a/v2.1/gbfs_versions.json
+++ b/v2.1/gbfs_versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#gbfs_versionsjson-added-in-v11",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/gbfs_versions.json-added-in-v11",
   "description":
     "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",

--- a/v2.1/geofencing_zones.json
+++ b/v2.1/geofencing_zones.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-  "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#geofencing_zonesjson",
+  "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/geofencing_zones.json",
   "description":
   "Describes geofencing zones and their associated rules and attributes (added in v2.1-RC).",
   "type": "object",

--- a/v2.1/station_information.json
+++ b/v2.1/station_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#station_informationjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/station_information.json",
   "description":
     "List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.",
   "type": "object",

--- a/v2.1/station_status.json
+++ b/v2.1/station_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#station_statusjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/station_status.json",
   "description":
     "Describes the capacity and rental availability of the station",
   "type": "object",

--- a/v2.1/system_alerts.json
+++ b/v2.1/system_alerts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#system_alertsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/system_alerts.json",
   "description": "Describes ad-hoc changes to the system.",
   "type": "object",
   "properties": {

--- a/v2.1/system_calendar.json
+++ b/v2.1/system_calendar.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#system_calendarjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/system_calendar.json",
   "description": "Describes the operating calendar for a system.",
   "type": "object",
   "properties": {

--- a/v2.1/system_hours.json
+++ b/v2.1/system_hours.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#system_hoursjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/system_hours.json",
   "description": "Describes the system hours of operation.",
   "type": "object",
   "properties": {

--- a/v2.1/system_information.json
+++ b/v2.1/system_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#system_informationjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/system_information.json",
   "description":
     "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",

--- a/v2.1/system_pricing_plans.json
+++ b/v2.1/system_pricing_plans.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#system_pricing_plansjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/system_pricing_plans.json",
   "description": "Describes the pricing schemes of the system.",
   "type": "object",
   "properties": {

--- a/v2.1/system_regions.json
+++ b/v2.1/system_regions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#system_regionsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/system_regions.json",
   "description":
     "Describes regions for a system that is broken up by geographic or political region.",
   "type": "object",

--- a/v2.1/vehicle_types.json
+++ b/v2.1/vehicle_types.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/vehicle_types.json-added-in-v21",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/vehicle_types.json",
   "description":
     "Describes the types of vehicles that System operator has available for rent (added in v2.1-RC).",
   "type": "object",

--- a/v2.1/vehicle_types.json
+++ b/v2.1/vehicle_types.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.1/gbfs.md#vehicle_typesjson-added-in-v21",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.1/vehicle_types.json-added-in-v21",
   "description":
     "Describes the types of vehicles that System operator has available for rent (added in v2.1-RC).",
   "type": "object",

--- a/v2.2/free_bike_status.json
+++ b/v2.2/free_bike_status.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#free_bike_statusjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.2/free_bike_status.json",
   "description":
     "Describes the vehicles that are available for rent (as of v2.1-RC2).",
   "type": "object",

--- a/v2.2/gbfs.json
+++ b/v2.2/gbfs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#gbfsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.2/gbfs.json",
   "description":
     "Auto-discovery file that links to all of the other files published by the system.",
   "type": "object",

--- a/v2.2/gbfs_versions.json
+++ b/v2.2/gbfs_versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.2/gbfs_versions.json-added-in-v11",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.2/gbfs_versions.json",
   "description":
     "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",

--- a/v2.2/gbfs_versions.json
+++ b/v2.2/gbfs_versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#gbfs_versionsjson-added-in-v11",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.2/gbfs_versions.json-added-in-v11",
   "description":
     "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",

--- a/v2.2/geofencing_zones.json
+++ b/v2.2/geofencing_zones.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#geofencing_zonesjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.2/geofencing_zones.json",
   "description":
     "Describes geofencing zones and their associated rules and attributes (added in v2.1-RC).",
   "type": "object",

--- a/v2.2/station_information.json
+++ b/v2.2/station_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#station_informationjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.2/station_information.json",
   "description":
     "List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.",
   "type": "object",

--- a/v2.2/station_status.json
+++ b/v2.2/station_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#station_statusjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.2/station_status.json",
   "description":
     "Describes the capacity and rental availability of the station",
   "type": "object",

--- a/v2.2/system_alerts.json
+++ b/v2.2/system_alerts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#system_alertsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.2/system_alerts.json",
   "description": "Describes ad-hoc changes to the system.",
   "type": "object",
   "properties": {

--- a/v2.2/system_calendar.json
+++ b/v2.2/system_calendar.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#system_calendarjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.2/system_calendar.json",
   "description": "Describes the operating calendar for a system.",
   "type": "object",
   "properties": {

--- a/v2.2/system_hours.json
+++ b/v2.2/system_hours.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#system_hoursjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.2/system_hours.json",
   "description": "Describes the system hours of operation.",
   "type": "object",
   "properties": {

--- a/v2.2/system_information.json
+++ b/v2.2/system_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#system_informationjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.2/system_information.json",
   "description":
     "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",

--- a/v2.2/system_pricing_plans.json
+++ b/v2.2/system_pricing_plans.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#system_pricing_plansjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.2/system_pricing_plans.json",
   "description": "Describes the pricing schemes of the system.",
   "type": "object",
   "properties": {

--- a/v2.2/system_regions.json
+++ b/v2.2/system_regions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#system_regionsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.2/system_regions.json",
   "description":
     "Describes regions for a system that is broken up by geographic or political region.",
   "type": "object",

--- a/v2.2/vehicle_types.json
+++ b/v2.2/vehicle_types.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.2/vehicle_types.json-added-in-v21",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.2/vehicle_types.json",
   "description":
     "Describes the types of vehicles that System operator has available for rent (added in v2.1-RC).",
   "type": "object",

--- a/v2.2/vehicle_types.json
+++ b/v2.2/vehicle_types.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.2/gbfs.md#vehicle_typesjson-added-in-v21",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.2/vehicle_types.json-added-in-v21",
   "description":
     "Describes the types of vehicles that System operator has available for rent (added in v2.1-RC).",
   "type": "object",

--- a/v2.3/free_bike_status.json
+++ b/v2.3/free_bike_status.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#free_bike_statusjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.3/free_bike_status.json",
   "description":
     "Describes the vehicles that are available for rent (as of v2.1-RC2).",
   "type": "object",

--- a/v2.3/gbfs.json
+++ b/v2.3/gbfs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#gbfsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.3/gbfs.json",
   "description":
     "Auto-discovery file that links to all of the other files published by the system.",
   "type": "object",

--- a/v2.3/gbfs_versions.json
+++ b/v2.3/gbfs_versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#gbfs_versionsjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.3/gbfs_versions.json",
   "description":
     "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",

--- a/v2.3/geofencing_zones.json
+++ b/v2.3/geofencing_zones.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#geofencing_zonesjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.3/geofencing_zones.json",
   "description":
     "Describes geofencing zones and their associated rules and attributes (added in v2.1-RC).",
   "type": "object",

--- a/v2.3/station_information.json
+++ b/v2.3/station_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#station_informationjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.3/station_information.json",
   "description":
     "List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.",
   "type": "object",

--- a/v2.3/station_status.json
+++ b/v2.3/station_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#station_statusjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.3/station_status.json",
   "description":
     "Describes the capacity and rental availability of the station",
   "type": "object",

--- a/v2.3/system_alerts.json
+++ b/v2.3/system_alerts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#system_alertsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.3/system_alerts.json",
   "description": "Describes ad-hoc changes to the system.",
   "type": "object",
   "properties": {

--- a/v2.3/system_calendar.json
+++ b/v2.3/system_calendar.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#system_calendarjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.3/system_calendar.json",
   "description": "Describes the operating calendar for a system.",
   "type": "object",
   "properties": {

--- a/v2.3/system_hours.json
+++ b/v2.3/system_hours.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#system_hoursjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.3/system_hours.json",
   "description": "Describes the system hours of operation.",
   "type": "object",
   "properties": {

--- a/v2.3/system_information.json
+++ b/v2.3/system_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#system_informationjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.3/system_information.json",
   "description":
     "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",

--- a/v2.3/system_pricing_plans.json
+++ b/v2.3/system_pricing_plans.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#system_pricing_plansjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.3/system_pricing_plans.json",
   "description": "Describes the pricing schemes of the system.",
   "type": "object",
   "properties": {

--- a/v2.3/system_regions.json
+++ b/v2.3/system_regions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#system_regionsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.3/system_regions.json",
   "description":
     "Describes regions for a system that is broken up by geographic or political region.",
   "type": "object",

--- a/v2.3/vehicle_types.json
+++ b/v2.3/vehicle_types.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#vehicle_typesjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v2.3/vehicle_types.json",
   "description":
     "Describes the types of vehicles that System operator has available for rent (added in v2.1-RC).",
   "type": "object",

--- a/v3.0/gbfs.json
+++ b/v3.0/gbfs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0/gbfs.md#gbfsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.0/gbfs.json",
   "description": "Auto-discovery file that links to all of the other files published by the system.",
   "type": "object",
   "properties": {

--- a/v3.0/gbfs_versions.json
+++ b/v3.0/gbfs_versions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0/gbfs.md#gbfs_versionsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.0/gbfs_versions.json",
   "description": "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",
   "properties": {

--- a/v3.0/geofencing_zones.json
+++ b/v3.0/geofencing_zones.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0/gbfs.md#geofencing_zonesjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.0/geofencing_zones.json",
   "description": "Describes geofencing zones and their associated rules and attributes (added in v2.1-RC).",
   "type": "object",
   "properties": {

--- a/v3.0/manifest.json
+++ b/v3.0/manifest.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0/gbfs.md#manifestjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.0/manifest.json",
   "description": "An index of gbfs.json URLs for each GBFS data set produced by a publisher. A single instance of this file should be published at a single stable URL, for example: https://example.com/gbfs/manifest.json.",
   "type": "object",
   "properties": {

--- a/v3.0/station_information.json
+++ b/v3.0/station_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v3.0/gbfs.md#station_informationjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.0/station_information.json",
   "description":
     "List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.",
   "type": "object",

--- a/v3.0/station_status.json
+++ b/v3.0/station_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0/gbfs.md#station_statusjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.0/station_status.json",
   "description":
     "Describes the capacity and rental availability of the station",
   "type": "object",

--- a/v3.0/system_alerts.json
+++ b/v3.0/system_alerts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0/gbfs.md#system_alertsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.0/system_alerts.json",
   "description": "Describes ad-hoc changes to the system.",
   "type": "object",
   "properties": {

--- a/v3.0/system_information.json
+++ b/v3.0/system_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v3.0/gbfs.md#system_informationjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.0/system_information.json",
   "description":
     "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",

--- a/v3.0/system_pricing_plans.json
+++ b/v3.0/system_pricing_plans.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v3.0/gbfs.md#system_pricing_plansjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.0/system_pricing_plans.json",
   "description": "Describes the pricing schemes of the system.",
   "type": "object",
   "properties": {

--- a/v3.0/system_regions.json
+++ b/v3.0/system_regions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs/blob/v3.0/gbfs.md#system_regionsjson",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.0/system_regions.json",
   "description":
     "Describes regions for a system that is broken up by geographic or political region.",
   "type": "object",

--- a/v3.0/vehicle_status.json
+++ b/v3.0/vehicle_status.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v3.0/gbfs.md#vehicle_statusjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.0/vehicle_status.json",
   "description":
     "Describes the vehicles that are available for rent (as of v3.0, formerly free_bike_status).",
   "type": "object",

--- a/v3.0/vehicle_types.json
+++ b/v3.0/vehicle_types.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs/blob/v3.0/gbfs.md#vehicle_typesjson",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.0/vehicle_types.json",
   "description":
     "Describes the types of vehicles that System operator has available for rent (added in v2.1-RC).",
   "type": "object",


### PR DESCRIPTION
While technically json schema $id was allowed to have # fragments in the uri, it was already [discouraged in Draft 7 and is forbidden for 2019-09 onward](https://json-schema.org/understanding-json-schema/structuring#id). As there is some tooling out there that has problems with fragment urls, I propose to point them to blobs in this repo instead. If this is considered problematic for released version, it should at least be applied for 3.1-RC.