### PR TITLE
Add validation for presence of required files in discovery file

### DIFF
--- a/v1.0/gbfs.json
+++ b/v1.0/gbfs.json
@@ -45,8 +45,7 @@
                     "type": "object",
                     "properties": {
                       "name": { "const": "system_information" }
-                    },
-                    "required": ["name"]
+                    }
                   }
                 }
               ]

--- a/v1.0/gbfs.json
+++ b/v1.0/gbfs.json
@@ -36,7 +36,20 @@
                   }
                 },
                 "required": ["name", "url"]
-              }
+              },
+              "minItems": 1,
+              "allOf": [
+                {
+                  "type": "array",
+                  "contains": {
+                    "type": "object",
+                    "properties": {
+                      "name": { "const": "system_information" }
+                    },
+                    "required": ["name"]
+                  }
+                }
+              ]
             }
           },
           "required": ["feeds"]

--- a/v1.0/gbfs.json
+++ b/v1.0/gbfs.json
@@ -38,17 +38,11 @@
                 "required": ["name", "url"]
               },
               "minItems": 1,
-              "allOf": [
-                {
-                  "type": "array",
-                  "contains": {
-                    "type": "object",
-                    "properties": {
-                      "name": { "const": "system_information" }
-                    }
-                  }
+              "contains": {
+                "properties": {
+                  "name": { "const": "system_information" }
                 }
-              ]
+              }
             }
           },
           "required": ["feeds"]

--- a/v1.1/gbfs.json
+++ b/v1.1/gbfs.json
@@ -71,8 +71,7 @@
                     "type": "object",
                     "properties": {
                       "name": { "const": "system_information" }
-                    },
-                    "required": ["name"]
+                    }
                   }
                 }
               ]

--- a/v1.1/gbfs.json
+++ b/v1.1/gbfs.json
@@ -62,7 +62,20 @@
                   }
                 },
                 "required": ["name", "url"]
-              }
+              },
+              "minItems": 1,
+              "allOf": [
+                {
+                  "type": "array",
+                  "contains": {
+                    "type": "object",
+                    "properties": {
+                      "name": { "const": "system_information" }
+                    },
+                    "required": ["name"]
+                  }
+                }
+              ]
             }
           },
           "required": ["feeds"]

--- a/v1.1/gbfs.json
+++ b/v1.1/gbfs.json
@@ -64,17 +64,11 @@
                 "required": ["name", "url"]
               },
               "minItems": 1,
-              "allOf": [
-                {
-                  "type": "array",
-                  "contains": {
-                    "type": "object",
-                    "properties": {
-                      "name": { "const": "system_information" }
-                    }
-                  }
+              "contains": {
+                "properties": {
+                  "name": { "const": "system_information" }
                 }
-              ]
+              }
             }
           },
           "required": ["feeds"]

--- a/v2.0/gbfs.json
+++ b/v2.0/gbfs.json
@@ -71,8 +71,7 @@
                     "type": "object",
                     "properties": {
                       "name": { "const": "system_information" }
-                    },
-                    "required": ["name"]
+                    }
                   }
                 }
               ]

--- a/v2.0/gbfs.json
+++ b/v2.0/gbfs.json
@@ -62,7 +62,20 @@
                   }
                 },
                 "required": ["name", "url"]
-              }
+              },
+              "minItems": 1,
+              "allOf": [
+                {
+                  "type": "array",
+                  "contains": {
+                    "type": "object",
+                    "properties": {
+                      "name": { "const": "system_information" }
+                    },
+                    "required": ["name"]
+                  }
+                }
+              ]
             }
           },
           "required": ["feeds"]

--- a/v2.0/gbfs.json
+++ b/v2.0/gbfs.json
@@ -64,17 +64,11 @@
                 "required": ["name", "url"]
               },
               "minItems": 1,
-              "allOf": [
-                {
-                  "type": "array",
-                  "contains": {
-                    "type": "object",
-                    "properties": {
-                      "name": { "const": "system_information" }
-                    }
-                  }
+              "contains": {
+                "properties": {
+                  "name": { "const": "system_information" }
                 }
-              ]
+              }
             }
           },
           "required": ["feeds"]

--- a/v2.1/gbfs.json
+++ b/v2.1/gbfs.json
@@ -64,7 +64,20 @@
                   }
                 },
                 "required": ["name", "url"]
-              }
+              },
+              "minItems": 1,
+              "allOf": [
+                {
+                  "type": "array",
+                  "contains": {
+                    "type": "object",
+                    "properties": {
+                      "name": { "const": "system_information" }
+                    },
+                    "required": ["name"]
+                  }
+                }
+              ]
             }
           },
           "required": ["feeds"]

--- a/v2.1/gbfs.json
+++ b/v2.1/gbfs.json
@@ -73,8 +73,7 @@
                     "type": "object",
                     "properties": {
                       "name": { "const": "system_information" }
-                    },
-                    "required": ["name"]
+                    }
                   }
                 }
               ]

--- a/v2.1/gbfs.json
+++ b/v2.1/gbfs.json
@@ -66,17 +66,11 @@
                 "required": ["name", "url"]
               },
               "minItems": 1,
-              "allOf": [
-                {
-                  "type": "array",
-                  "contains": {
-                    "type": "object",
-                    "properties": {
-                      "name": { "const": "system_information" }
-                    }
-                  }
+              "contains": {
+                "properties": {
+                  "name": { "const": "system_information" }
                 }
-              ]
+              }
             }
           },
           "required": ["feeds"]

--- a/v2.2/gbfs.json
+++ b/v2.2/gbfs.json
@@ -64,7 +64,20 @@
                   }
                 },
                 "required": ["name", "url"]
-              }
+              },
+              "minItems": 1,
+              "allOf": [
+                {
+                  "type": "array",
+                  "contains": {
+                    "type": "object",
+                    "properties": {
+                      "name": { "const": "system_information" }
+                    },
+                    "required": ["name"]
+                  }
+                }
+              ]
             }
           },
           "required": ["feeds"]

--- a/v2.2/gbfs.json
+++ b/v2.2/gbfs.json
@@ -73,8 +73,7 @@
                     "type": "object",
                     "properties": {
                       "name": { "const": "system_information" }
-                    },
-                    "required": ["name"]
+                    }
                   }
                 }
               ]

--- a/v2.2/gbfs.json
+++ b/v2.2/gbfs.json
@@ -66,17 +66,11 @@
                 "required": ["name", "url"]
               },
               "minItems": 1,
-              "allOf": [
-                {
-                  "type": "array",
-                  "contains": {
-                    "type": "object",
-                    "properties": {
-                      "name": { "const": "system_information" }
-                    }
-                  }
+              "contains": {
+                "properties": {
+                  "name": { "const": "system_information" }
                 }
-              ]
+              }
             }
           },
           "required": ["feeds"]

--- a/v2.3/gbfs.json
+++ b/v2.3/gbfs.json
@@ -64,7 +64,20 @@
                   }
                 },
                 "required": ["name", "url"]
-              }
+              },
+              "minItems": 1,
+              "allOf": [
+                {
+                  "type": "array",
+                  "contains": {
+                    "type": "object",
+                    "properties": {
+                      "name": { "const": "system_information" }
+                    },
+                    "required": ["name"]
+                  }
+                }
+              ]
             }
           },
           "required": ["feeds"]

--- a/v2.3/gbfs.json
+++ b/v2.3/gbfs.json
@@ -73,8 +73,7 @@
                     "type": "object",
                     "properties": {
                       "name": { "const": "system_information" }
-                    },
-                    "required": ["name"]
+                    }
                   }
                 }
               ]

--- a/v2.3/gbfs.json
+++ b/v2.3/gbfs.json
@@ -66,17 +66,11 @@
                 "required": ["name", "url"]
               },
               "minItems": 1,
-              "allOf": [
-                {
-                  "type": "array",
-                  "contains": {
-                    "type": "object",
-                    "properties": {
-                      "name": { "const": "system_information" }
-                    }
-                  }
+              "contains": {
+                "properties": {
+                  "name": { "const": "system_information" }
                 }
-              ]
+              }
             }
           },
           "required": ["feeds"]

--- a/v3.0/gbfs.json
+++ b/v3.0/gbfs.json
@@ -54,17 +54,11 @@
             "required": ["name", "url"]
           },
           "minItems": 1,
-          "allOf": [
-            {
-              "type": "array",
-              "contains": {
-                "type": "object",
-                "properties": {
-                  "name": { "const": "system_information" }
-                }
-              }
+          "contains": {
+            "properties": {
+              "name": { "const": "system_information" }
             }
-          ]
+          }
         }
       },
       "required": ["feeds"]

--- a/v3.0/gbfs.json
+++ b/v3.0/gbfs.json
@@ -53,7 +53,19 @@
             },
             "required": ["name", "url"]
           },
-          "minItems": 1
+          "minItems": 1,
+          "allOf": [
+            {
+              "type": "array",
+              "contains": {
+                "type": "object",
+                "properties": {
+                  "name": { "const": "system_information" }
+                },
+                "required": ["name"]
+              }
+            }
+          ]
         }
       },
       "required": ["feeds"]

--- a/v3.0/gbfs.json
+++ b/v3.0/gbfs.json
@@ -61,8 +61,7 @@
                 "type": "object",
                 "properties": {
                   "name": { "const": "system_information" }
-                },
-                "required": ["name"]
+                }
               }
             }
           ]

--- a/v3.1-RC/gbfs.json
+++ b/v3.1-RC/gbfs.json
@@ -54,17 +54,11 @@
             "required": ["name", "url"]
           },
           "minItems": 1,
-          "allOf": [
-            {
-              "type": "array",
-              "contains": {
-                "type": "object",
-                "properties": {
-                  "name": { "const": "system_information" }
-                }
-              }
+          "contains": {
+            "properties": {
+              "name": { "const": "system_information" }
             }
-          ]
+          }
         }
       },
       "required": ["feeds"]

--- a/v3.1-RC/gbfs.json
+++ b/v3.1-RC/gbfs.json
@@ -53,7 +53,19 @@
             },
             "required": ["name", "url"]
           },
-          "minItems": 1
+          "minItems": 1,
+          "allOf": [
+            {
+              "type": "array",
+              "contains": {
+                "type": "object",
+                "properties": {
+                  "name": { "const": "system_information" }
+                },
+                "required": ["name"]
+              }
+            }
+          ]
         }
       },
       "required": ["feeds"]

--- a/v3.1-RC/gbfs.json
+++ b/v3.1-RC/gbfs.json
@@ -61,8 +61,7 @@
                 "type": "object",
                 "properties": {
                   "name": { "const": "system_information" }
-                },
-                "required": ["name"]
+                }
               }
             }
           ]


### PR DESCRIPTION
Currently, validators (including Entur's) check for required files "manually", i.e. does the file exist if I try to fetch it. Imho this is backwards. We should check for required files using json schema validation on the discovery file. If required files are listed there, we should assume the feed is valid on the account of including required files. If subsequently we are unable to fetch that file, it should not be a validation error. Failure to fetch it can be for a number of reasons - none of which really have anything to do with validation.

This PR improves the JSON schema for the discovery files so that it checks for the listing of required files - thus providing a validation error if some are missing.

---

~~Please note that this PR is still a draft because I need to test that it actually does what I think it does.~~

I've updated the PR with a working tested implementation. An interesting outcome of this is that a lot of the examples fail this new validation because in fact they do not list the discovery-file itself (self-reference). Without getting too philosophical, it's not clear to me from reading the spec whether self-referencing the discovery file is actually expected. I've seen *some* feeds do it in the wild, but not all. The question is, if we don't require self-referencing, are we still covernig our bases. I would argue that yes, we are, because without the discovery file we would not be able to do any validation in the first place.

Update: removed requirement for self-referencing the discovery file.