### PR TITLE
Fix free_bike_status last_reported data type

### DIFF
--- a/v2.1/free_bike_status.json
+++ b/v2.1/free_bike_status.json
@@ -91,7 +91,7 @@
               "last_reported": {
                 "description":
                   "The last time this vehicle reported its status to the operator's backend in POSIX time (added in v2.1-RC).",
-                "type": "number",
+                "type": "integer",
                 "minimum": 1450155600
               },
               "current_range_meters": {

--- a/v2.2/free_bike_status.json
+++ b/v2.2/free_bike_status.json
@@ -91,7 +91,7 @@
               "last_reported": {
                 "description":
                   "The last time this vehicle reported its status to the operator's backend in POSIX time (added in v2.1-RC).",
-                "type": "number",
+                "type": "integer",
                 "minimum": 1450155600
               },
               "current_range_meters": {

--- a/v2.3/free_bike_status.json
+++ b/v2.3/free_bike_status.json
@@ -85,7 +85,7 @@
               },
               "last_reported": {
                 "description": "The last time this vehicle reported its status to the operator's backend in POSIX time (added in v2.1-RC).",
-                "type": "number",
+                "type": "integer",
                 "minimum": 1450155600
               },
               "current_range_meters": {


### PR DESCRIPTION
## Context
As pointed out by @hbruch on [Slack](https://mobilitydata-io.slack.com/archives/CNXA9ASBV/p1752250135346869): in the GBFS JSON Schema (v2.1, v2.2 and v2.3), free_bike_status‘ vehicle.last_reported should be an integer to match the [spec](https://github.com/MobilityData/gbfs/blob/v2.3/gbfs.md#field-types): "Timestamp fields MUST be represented as integers in POSIX time".

## What's Changed
Fixed free_bike_status last_reported data type in v2.1, v2.2 and v2.3:

- Before : `number`
- After : `integer`