### PR TITLE
Replaces  'last_updated' values in test fixtures to conform to schema

### DIFF
--- a/testFixtures/v2.3/gbfs_versions.json
+++ b/testFixtures/v2.3/gbfs_versions.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": 1434054678,
+  "last_updated": 1751437263,
   "ttl": 0,
   "version": "2.3",
   "data": {

--- a/testFixtures/v2.3/geofencing_zones.json
+++ b/testFixtures/v2.3/geofencing_zones.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": 1434054678,
+  "last_updated": 1751437263,
   "ttl": 0,
   "version": "2.3",
   "data": {

--- a/testFixtures/v2.3/station_information.json
+++ b/testFixtures/v2.3/station_information.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": 1434054678,
+  "last_updated": 1751437263,
   "ttl": 0,
   "version": "2.3",
   "data": {

--- a/testFixtures/v2.3/station_status.json
+++ b/testFixtures/v2.3/station_status.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": 1434054678,
+  "last_updated": 1751437263,
   "ttl": 0,
   "version": "2.3",
   "data": {
@@ -9,7 +9,7 @@
         "is_installed": true,
         "is_renting": true,
         "is_returning": true,
-        "last_reported": 1434054678,
+        "last_reported": 1751437263,
         "num_docks_available": 3,
         "vehicle_docks_available": [
           {
@@ -38,7 +38,7 @@
         "is_installed": true,
         "is_renting": true,
         "is_returning": true,
-        "last_reported": 1434054678,
+        "last_reported": 1751437263,
         "num_docks_available": 8,
         "vehicle_docks_available": [
           {

--- a/testFixtures/v2.3/system_alerts.json
+++ b/testFixtures/v2.3/system_alerts.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": 1434054678,
+  "last_updated": 1751434987,
   "ttl": 0,
   "version": "2.3",
   "data": {
@@ -9,14 +9,14 @@
         "type": "station_closure",
         "times": [
           {
-            "start": 1434054678,
-            "end": 1434054987
+            "start": 1751437263,
+            "end": 1751434987
           }
         ],
         "station_ids": ["TST:Station:1"],
         "summary": "Closed for maintenance",
         "description": "Station is closed to install more docks.",
-        "last_updated": 1434054678
+        "last_updated": 1751434987
       }
     ]
   }

--- a/testFixtures/v2.3/system_calendar.json
+++ b/testFixtures/v2.3/system_calendar.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": 1434054678,
+  "last_updated": 1751437263,
   "ttl": 0,
   "version": "2.3",
   "data": {

--- a/testFixtures/v2.3/system_hours.json
+++ b/testFixtures/v2.3/system_hours.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": 1434054678,
+  "last_updated": 1751437263,
   "ttl": 0,
   "version": "2.3",
   "data": {


### PR DESCRIPTION
Replaces  'last_updated' and related timestamps in multiple test fixture files with values respecting the minimum allowed timestamp for this field. No logic changes or new functionality introduced.