### PR TITLE
fix: cargo lock version 0.1.3

### DIFF
--- a/models/rust/Cargo.lock
+++ b/models/rust/Cargo.lock
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "gbfs_types"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "futures",
  "geo-types",


### PR DESCRIPTION
# Description

This PR aligns the cargo package version with the cargo lock version.
Fixes failing [build](https://github.com/MobilityData/gbfs-json-schema/actions/runs/16752411787/job/47425990526)