### PR TITLE
fix: rust cargo categories

### DIFF
--- a/models/rust/Cargo.toml
+++ b/models/rust/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["MobilityData <it@mobilitydata.org>", "Tom Delmas <tom.delmas@fluctuo
 repository = "https://github.com/MobilityData/gbfs-json-schema"
 homepage = "https://github.com/MobilityData/gbfs-json-schema/tree/master/models/rust"
 keywords = ["gbfs", "types"]
-categories = ["transit", "mobility"]
+categories = ["api-bindings"]
 readme = "README.md"
 
 [features]


### PR DESCRIPTION
# Description

Fix cargo crate categories. It appears that the crates community has recently been enforced with an approval list of categories. This PR updates the category list for the package.