### PR TITLE
Fix/update npm token to trusted publisher

### DIFF
--- a/.github/workflows/typescript_package_publish.yml
+++ b/.github/workflows/typescript_package_publish.yml
@@ -6,7 +6,6 @@ on:
     push:
       branches:
         - master
-        - fix/update-npm-token-to-trusted-publisher
       paths:
         - "models/typescript/**"
 

--- a/.github/workflows/typescript_package_publish.yml
+++ b/.github/workflows/typescript_package_publish.yml
@@ -42,6 +42,9 @@ jobs:
             # Ensure npm 11.5.1 or later is installed
             - name: Update npm
               run: npm install -g npm@latest
+
+            - name: Print NPM version after update
+              run: npm --version
       
             - name: Publish to npm
               run: cd ./models/typescript && npm publish --dry-run

--- a/.github/workflows/typescript_package_publish.yml
+++ b/.github/workflows/typescript_package_publish.yml
@@ -35,17 +35,11 @@ jobs:
               run: |
                 cd ./scripts
                 yarn
-
-            - name: Print NPM version
-              run: npm --version
             
-            # Ensure npm 11.5.1 or later is installed
+            # Ensure npm 11.5.1 or later is installed for OIDC support
             - name: Update npm
-              run: npm install -g npm@latest
-
-            - name: Print NPM version after update
-              run: npm --version
+              run: npm install -g npm@11.6.2
       
             - name: Publish to npm
-              run: cd ./models/typescript && npm publish --dry-run
+              run: cd ./models/typescript && npm publish
                 

--- a/.github/workflows/typescript_package_publish.yml
+++ b/.github/workflows/typescript_package_publish.yml
@@ -6,8 +6,16 @@ on:
     push:
       branches:
         - master
+        - fix/update-npm-token-to-trusted-publisher
       paths:
         - "models/typescript/**"
+
+# Npm authentication via OpenID Connect (OIDC)
+# https://docs.npmjs.com/trusted-publishers
+permissions:
+    id-token: write  # Required for OIDC
+    contents: read
+  
 jobs:
     build-publish:
         name: build-publish-job
@@ -15,12 +23,12 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Setup Node.js
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v4
               with:
-                node-version: '18'
+                node-version: '20'
                 registry-url: 'https://registry.npmjs.org'
     
             - name: Install dependencies
@@ -28,16 +36,13 @@ jobs:
                 cd ./scripts
                 yarn
 
-            - name: Load secrets from 1Password
-              uses: 1password/load-secrets-action@v2.0.0
-              with:
-                export-env: true # Export loaded secrets as environment variables
-              env:
-                OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-                NODE_AUTH_TOKEN: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/ppzc4jxrwkf3omdmcs7z2wiwum/credential"
+            - name: Print NPM version
+              run: npm --version
+            
+            # Ensure npm 11.5.1 or later is installed
+            - name: Update npm
+              run: npm install -g npm@latest
       
             - name: Publish to npm
-              run: cd ./models/typescript && npm publish
-              env:
-                NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
+              run: cd ./models/typescript && npm publish --dry-run
                 

--- a/models/typescript/README.md
+++ b/models/typescript/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/gbfs-typescript-types.svg)](http://badge.fury.io/js/gbfs-typescript-types)
 
-TypeScript types for parsing and working with General Bikeshare Feed Specification (GBFS) data, ensuring type safety and code consistency in TypeScript projects
+TypeScript types for parsing and working with General Bikeshare Feed Specification (GBFS) data, ensuring type safety and code consistency in TypeScript projects.
 
 ## Add the Dependency
 

--- a/models/typescript/README.md
+++ b/models/typescript/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/gbfs-typescript-types.svg)](http://badge.fury.io/js/gbfs-typescript-types)
 
-TypeScript types for parsing and working with General Bikeshare Feed Specification (GBFS) data, ensuring type safety and code consistency in TypeScript projects.
+TypeScript types for parsing and working with General Bikeshare Feed Specification (GBFS) data, ensuring type safety and code consistency in TypeScript projects
 
 ## Add the Dependency
 

--- a/models/typescript/package.json
+++ b/models/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gbfs-typescript-types",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Language Bindings for GBFS in Typescript.",
   "keywords": [
     "gbfs",

--- a/models/typescript/package.json
+++ b/models/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gbfs-typescript-types",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Language Bindings for GBFS in Typescript.",
   "keywords": [
     "gbfs",


### PR DESCRIPTION
With the new NPM [security updates](https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/) coming out soon, we will need to change our authentication strategy when publishing packages

Instead of rotating tokens every 90 days, we will use npm's [trusted publishers](https://docs.npmjs.com/trusted-publishers) as a method of authentication. We will no longer need to handle NPM TOKENs

Proof of success
https://github.com/MobilityData/gbfs-json-schema/actions/runs/18689353734/job/53290636729

<img width="465" height="364" alt="image" src="https://github.com/user-attachments/assets/e0bd3497-1cec-40db-98f1-3858c6c7143d" />

