### PR TITLE
java models for 3.1-rc2

### DIFF
--- a/models/java/gbfs-java-model/bin/schema-to-subfolders.sh
+++ b/models/java/gbfs-java-model/bin/schema-to-subfolders.sh
@@ -13,7 +13,7 @@ rm -rf ./models/java/gbfs-java-model/resources
 output_path="./models/java/gbfs-java-model/resources/"
 path_to_schemas="."
 
-versions=("v3.0" "v2.3" "v2.2" "v2.1" "v2.0" "v1.1" "v1.0")
+versions=("v3.1-RC2" "v3.0" "v2.3" "v2.2" "v2.1" "v2.0" "v1.1" "v1.0")
 
 echo "Start Schema to Subfolders Script"
 

--- a/models/java/gbfs-java-model/pom.xml
+++ b/models/java/gbfs-java-model/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mobilitydata</groupId>
     <artifactId>gbfs-java-model</artifactId>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
 
     <name>gbfs-java-model</name>
 
@@ -253,6 +253,25 @@
                             <generateBuilders>true</generateBuilders>
                             <sourceDirectory>${basedir}/resources/v3.0</sourceDirectory>
                             <targetPackage>org.mobilitydata.gbfs.v3_0</targetPackage>
+                            <customRuleFactory>org.mobilitydata.gbfs.GeofencingRuleFactory</customRuleFactory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-v3.1-RC2-sources</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <classNamePrefix>GBFS</classNamePrefix>
+                            <formatTypeMapping>
+                                <uri>java.lang.String</uri>
+                            </formatTypeMapping>
+                            <removeOldOutput>false</removeOldOutput>
+                            <serializable>true</serializable>
+                            <initializeCollections>false</initializeCollections>
+                            <generateBuilders>true</generateBuilders>
+                            <sourceDirectory>${basedir}/resources/v3.1-RC2</sourceDirectory>
+                            <targetPackage>org.mobilitydata.gbfs.v3_1_RC2</targetPackage>
                             <customRuleFactory>org.mobilitydata.gbfs.GeofencingRuleFactory</customRuleFactory>
                         </configuration>
                     </execution>

--- a/models/java/gbfs-java-model/src/main/java/org/mobilitydata/gbfs/v3_1_RC2/gbfs/GBFSFeedName.java
+++ b/models/java/gbfs-java-model/src/main/java/org/mobilitydata/gbfs/v3_1_RC2/gbfs/GBFSFeedName.java
@@ -1,0 +1,48 @@
+package org.mobilitydata.gbfs.v3_1_RC2.gbfs;
+
+import org.mobilitydata.gbfs.v3_1_RC2.gbfs_versions.GBFSGbfsVersions;
+import org.mobilitydata.gbfs.v3_1_RC2.geofencing_zones.GBFSGeofencingZones;
+import org.mobilitydata.gbfs.v3_1_RC2.station_information.GBFSStationInformation;
+import org.mobilitydata.gbfs.v3_1_RC2.station_status.GBFSStationStatus;
+import org.mobilitydata.gbfs.v3_1_RC2.system_alerts.GBFSSystemAlerts;
+import org.mobilitydata.gbfs.v3_1_RC2.system_information.GBFSSystemInformation;
+import org.mobilitydata.gbfs.v3_1_RC2.system_pricing_plans.GBFSSystemPricingPlans;
+import org.mobilitydata.gbfs.v3_1_RC2.system_regions.GBFSSystemRegions;
+import org.mobilitydata.gbfs.v3_1_RC2.vehicle_status.GBFSVehicleStatus;
+import org.mobilitydata.gbfs.v3_1_RC2.vehicle_types.GBFSVehicleTypes;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class GBFSFeedName {
+    private GBFSFeedName() {}
+
+
+    private static final Map<GBFSFeed.Name, Class<?>> feedNameMap = new EnumMap<>(GBFSFeed.Name.class);
+
+    private static final Map<Class<?>, GBFSFeed.Name> classMap;
+
+    static {
+        feedNameMap.put(GBFSFeed.Name.GBFS, GBFSGbfs.class);
+        feedNameMap.put(GBFSFeed.Name.GBFS_VERSIONS, GBFSGbfsVersions.class);
+        feedNameMap.put(GBFSFeed.Name.GEOFENCING_ZONES, GBFSGeofencingZones.class);
+        feedNameMap.put(GBFSFeed.Name.STATION_INFORMATION, GBFSStationInformation.class);
+        feedNameMap.put(GBFSFeed.Name.STATION_STATUS, GBFSStationStatus.class);
+        feedNameMap.put(GBFSFeed.Name.SYSTEM_ALERTS, GBFSSystemAlerts.class);
+        feedNameMap.put(GBFSFeed.Name.SYSTEM_INFORMATION, GBFSSystemInformation.class);
+        feedNameMap.put(GBFSFeed.Name.SYSTEM_PRICING_PLANS, GBFSSystemPricingPlans.class);
+        feedNameMap.put(GBFSFeed.Name.SYSTEM_REGIONS, GBFSSystemRegions.class);
+        feedNameMap.put(GBFSFeed.Name.VEHICLE_STATUS, GBFSVehicleStatus.class);
+        feedNameMap.put(GBFSFeed.Name.VEHICLE_TYPES, GBFSVehicleTypes.class);
+        classMap = feedNameMap.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+    }
+
+    public static Class<?> implementingClass(GBFSFeed.Name feedName) {
+        return feedNameMap.get(feedName);
+    }
+
+    public static GBFSFeed.Name fromClass(Class<?> clazz) {
+        return classMap.get(clazz);
+    }
+}

--- a/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/gbfs/GBFSFeedNameTest.java
+++ b/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/gbfs/GBFSFeedNameTest.java
@@ -1,0 +1,30 @@
+package org.mobilitydata.gbfs.v3_1_RC2.gbfs;
+
+import org.mobilitydata.gbfs.v3_1_RC2.station_information.GBFSStationInformation;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GBFSFeedNameTest {
+
+    @Test
+    void value() {
+        Assertions.assertEquals("station_information", org.mobilitydata.gbfs.v3_1_RC2.gbfs.GBFSFeed.Name.STATION_INFORMATION.value());
+    }
+
+    @Test
+    void implementingClass() {
+        assertEquals(GBFSStationInformation.class, org.mobilitydata.gbfs.v3_1_RC2.gbfs.GBFSFeedName.implementingClass(org.mobilitydata.gbfs.v3_1_RC2.gbfs.GBFSFeed.Name.STATION_INFORMATION));
+    }
+
+    @Test
+    void fromValue() {
+        assertEquals(org.mobilitydata.gbfs.v3_1_RC2.gbfs.GBFSFeed.Name.STATION_INFORMATION, org.mobilitydata.gbfs.v3_1_RC2.gbfs.GBFSFeed.Name.fromValue("station_information"));
+    }
+
+    @Test
+    void fromClass() {
+        assertEquals(GBFSFeed.Name.STATION_INFORMATION, GBFSFeedName.fromClass(GBFSStationInformation.class));
+    }
+}

--- a/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/gbfs/GBFSTest.java
+++ b/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/gbfs/GBFSTest.java
@@ -1,0 +1,11 @@
+package org.mobilitydata.gbfs.v3_1_RC2.gbfs;
+
+import org.mobilitydata.gbfs.TestBase;
+import org.junit.jupiter.api.Test;
+
+class GBFSTest extends TestBase {
+    @Test
+    void testUnmarshal() {
+        assertUnmarshalDoesNotThrow("v3_1_RC2/gbfs.json", GBFSGbfs.class);
+    }
+}

--- a/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/gbfs_versions/GBFSVersionsTest.java
+++ b/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/gbfs_versions/GBFSVersionsTest.java
@@ -1,0 +1,12 @@
+package org.mobilitydata.gbfs.v3_1_RC2.gbfs_versions;
+
+import org.mobilitydata.gbfs.TestBase;
+
+import org.junit.jupiter.api.Test;
+
+class GBFSVersionsTest extends TestBase {
+    @Test
+    void testUnmarshal() {
+        assertUnmarshalDoesNotThrow("v3_1_RC2/gbfs_versions.json", GBFSGbfsVersions.class);
+    }
+}

--- a/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/geofencing_zones/GeofencingZonesTest.java
+++ b/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/geofencing_zones/GeofencingZonesTest.java
@@ -1,0 +1,19 @@
+package org.mobilitydata.gbfs.v3_1_RC2.geofencing_zones;
+
+import org.mobilitydata.gbfs.TestBase;
+
+import org.geojson.LngLatAlt;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GeofencingZonesTest extends TestBase {
+    @Test
+    void testUnmarshal() {
+        GBFSGeofencingZones zones = assertUnmarshalDoesNotThrow("v3_1_RC2/geofencing_zones.json", GBFSGeofencingZones.class);
+        GBFSFeature feature = zones.getData().getGeofencingZones().getFeatures().get(0);
+        LngLatAlt coord = feature.getGeometry().getCoordinates().get(0).get(0).get(0);
+        assertEquals(45.562982, coord.getLatitude(), 0.01);
+        assertEquals(-122.578067, coord.getLongitude());
+    }
+}

--- a/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/manifest/ManifestTest.java
+++ b/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/manifest/ManifestTest.java
@@ -1,0 +1,12 @@
+package org.mobilitydata.gbfs.v3_1_RC2.manifest;
+
+import org.mobilitydata.gbfs.TestBase;
+
+import org.junit.jupiter.api.Test;
+
+class ManifestTest extends TestBase {
+    @Test
+    void testUnmarshal() {
+        assertUnmarshalDoesNotThrow("v3_1_RC2/manifest.json", GBFSManifest.class);
+    }
+}

--- a/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/station_information/StationInformationTest.java
+++ b/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/station_information/StationInformationTest.java
@@ -1,0 +1,11 @@
+package org.mobilitydata.gbfs.v3_1_RC2.station_information;
+
+import org.mobilitydata.gbfs.TestBase;
+import org.junit.jupiter.api.Test;
+
+class StationInformationTest extends TestBase {
+    @Test
+    void testUnmarshal() {
+        assertUnmarshalDoesNotThrow("v3_1_RC2/station_information.json", GBFSStationInformation.class);
+    }
+}

--- a/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/station_status/StationStatusTest.java
+++ b/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/station_status/StationStatusTest.java
@@ -1,0 +1,11 @@
+package org.mobilitydata.gbfs.v3_1_RC2.station_status;
+
+import org.mobilitydata.gbfs.TestBase;
+import org.junit.jupiter.api.Test;
+
+class StationStatusTest extends TestBase {
+    @Test
+    void testUnmarshal() {
+        assertUnmarshalDoesNotThrow("v3_1_RC2/station_status.json", GBFSStationStatus.class);
+    }
+}

--- a/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/system_alerts/SystemAlertsTest.java
+++ b/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/system_alerts/SystemAlertsTest.java
@@ -1,0 +1,11 @@
+package org.mobilitydata.gbfs.v3_1_RC2.system_alerts;
+
+import org.mobilitydata.gbfs.TestBase;
+import org.junit.jupiter.api.Test;
+
+class SystemAlertsTest extends TestBase {
+    @Test
+    void testUnmarshal() {
+        assertUnmarshalDoesNotThrow("v3_1_RC2/system_alerts.json", GBFSSystemAlerts.class);
+    }
+}

--- a/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/system_information/SystemInformationTest.java
+++ b/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/system_information/SystemInformationTest.java
@@ -1,0 +1,11 @@
+package org.mobilitydata.gbfs.v3_1_RC2.system_information;
+
+import org.mobilitydata.gbfs.TestBase;
+import org.junit.jupiter.api.Test;
+
+class SystemInformationTest extends TestBase {
+    @Test
+    void testUnmarshal() {
+        assertUnmarshalDoesNotThrow("v3_1_RC2/system_information.json", GBFSSystemInformation.class);
+    }
+}

--- a/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/system_pricing_plans/SystemPricingPlansTest.java
+++ b/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/system_pricing_plans/SystemPricingPlansTest.java
@@ -1,0 +1,11 @@
+package org.mobilitydata.gbfs.v3_1_RC2.system_pricing_plans;
+
+import org.mobilitydata.gbfs.TestBase;
+import org.junit.jupiter.api.Test;
+
+class SystemPricingPlansTest extends TestBase {
+    @Test
+    void testUnmarshal() {
+        assertUnmarshalDoesNotThrow("v3_1_RC2/system_pricing_plans.json", GBFSSystemPricingPlans.class);
+    }
+}

--- a/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/system_regions/SystemRegionsTest.java
+++ b/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/system_regions/SystemRegionsTest.java
@@ -1,0 +1,11 @@
+package org.mobilitydata.gbfs.v3_1_RC2.system_regions;
+
+import org.mobilitydata.gbfs.TestBase;
+import org.junit.jupiter.api.Test;
+
+class SystemRegionsTest extends TestBase {
+    @Test
+    void testUnmarshal() {
+        assertUnmarshalDoesNotThrow("v3_1_RC2/system_regions.json", GBFSSystemRegions.class);
+    }
+}

--- a/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/vehicle_availability/VehicleAvailabilityTest.java
+++ b/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/vehicle_availability/VehicleAvailabilityTest.java
@@ -1,0 +1,11 @@
+package org.mobilitydata.gbfs.v3_1_RC2.vehicle_availability;
+
+import org.mobilitydata.gbfs.TestBase;
+import org.junit.jupiter.api.Test;
+
+class VehicleAvailabilityTest extends TestBase {
+	@Test
+	void testUnmarshal() {
+		assertUnmarshalDoesNotThrow("v3_1_RC2/vehicle_availability.json", GBFSVehicleAvailability.class);
+	}
+}

--- a/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/vehicle_status/VehicleStatusTest.java
+++ b/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/vehicle_status/VehicleStatusTest.java
@@ -1,0 +1,11 @@
+package org.mobilitydata.gbfs.v3_1_RC2.vehicle_status;
+
+import org.mobilitydata.gbfs.TestBase;
+import org.junit.jupiter.api.Test;
+
+class VehicleStatusTest extends TestBase {
+    @Test
+    void testUnmarshal() {
+        assertUnmarshalDoesNotThrow("v3_1_RC2/vehicle_status.json", GBFSVehicleStatus.class);
+    }
+}

--- a/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/vehicle_types/VehicleTypesTest.java
+++ b/models/java/gbfs-java-model/src/test/java/org/mobilitydata/gbfs/v3_1_RC2/vehicle_types/VehicleTypesTest.java
@@ -1,0 +1,11 @@
+package org.mobilitydata.gbfs.v3_1_RC2.vehicle_types;
+
+import org.mobilitydata.gbfs.TestBase;
+import org.junit.jupiter.api.Test;
+
+class VehicleTypesTest extends TestBase {
+    @Test
+    void testUnmarshal() {
+        assertUnmarshalDoesNotThrow("v3_1_RC2/vehicle_types.json", GBFSVehicleTypes.class);
+    }
+}

--- a/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/gbfs.json
+++ b/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/gbfs.json
@@ -1,0 +1,17 @@
+{
+    "last_updated": "2023-07-17T13:34:13+02:00",
+    "ttl": 0,
+    "version": "3.1-RC2",
+    "data": {
+      "feeds": [
+        {
+          "name": "system_information",
+          "url": "https://www.example.com/gbfs/1/system_information"
+        },
+        {
+          "name": "station_information",
+          "url": "https://www.example.com/gbfs/1/station_information"
+        }
+      ]
+    }
+  }

--- a/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/gbfs_versions.json
+++ b/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/gbfs_versions.json
@@ -1,0 +1,17 @@
+{
+    "last_updated": "2023-07-17T13:34:13+02:00",
+    "ttl": 0,
+    "version": "3.1-RC2",
+    "data": {
+      "versions": [
+        {
+          "version": "2.0",
+          "url": "https://www.example.com/gbfs/2/gbfs"
+        },
+        {
+          "version": "3.1-RC2",
+          "url": "https://www.example.com/gbfs/3.1-RC2/gbfs"
+        }
+      ]
+    }
+  }

--- a/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/geofencing_zones.json
+++ b/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/geofencing_zones.json
@@ -1,0 +1,74 @@
+{
+    "last_updated": "2023-07-17T13:34:13+02:00",
+    "ttl": 60,
+    "version": "3.1-RC2",
+    "data": {
+      "geofencing_zones": {
+        "type": "FeatureCollection",
+        "features": [
+          {
+            "type": "Feature",
+            "geometry": {
+              "type": "MultiPolygon",
+              "coordinates": [
+                [
+                  [
+                    [
+                      -122.578067,
+                      45.562982
+                    ],
+                    [
+                      -122.661838,
+                      45.562741
+                    ],
+                    [
+                      -122.661151,
+                      45.504542
+                    ],
+                    [
+                      -122.578926,
+                      45.5046625
+                    ],
+                    [
+                      -122.578067,
+                      45.562982
+                    ]
+                  ]
+                ]
+              ]
+            },
+            "properties": {
+              "name": [
+                {
+                  "text": "NE 24th/NE Knott",
+                  "language": "en"
+                }
+              ],
+              "start": "2023-07-17T13:34:13+02:00",
+              "end": "2024-07-18T13:34:13+02:00",
+              "rules": [
+                {
+                  "vehicle_type_ids": [
+                    "moped1",
+                    "car1"
+                  ],
+                  "ride_start_allowed": true,
+                  "ride_end_allowed": true,
+                  "maximum_speed_kph": 10,
+                  "station_parking": true,
+                  "ride_through_allowed": false 
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "global_rules": [
+        {
+          "ride_start_allowed": false,
+          "ride_end_allowed": false,
+          "ride_through_allowed": true
+        }
+      ]
+    }
+  }

--- a/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/manifest.json
+++ b/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/manifest.json
@@ -1,0 +1,115 @@
+{
+    "last_updated": "2023-07-17T13:34:13+02:00",
+    "ttl":0,
+    "version": "3.1-RC2",
+    "data":{
+      "datasets":[
+        {
+          "system_id":"example_berlin",
+          "versions":[
+            {
+              "version": "2.0",
+              "url":"https://berlin.example.com/gbfs/2/gbfs"
+            },
+            {
+              "version": "3.1-RC2",
+              "url":"https://berlin.example.com/gbfs/3.1-RC2/gbfs"
+            }
+          ],
+          "area": {
+            "type": "MultiPolygon",
+            "coordinates": [
+              [
+                [
+                  [
+                    13.10821,
+                    52.58563
+                  ],
+                  [
+                    13.29743,
+                    52.67046
+                  ],
+                  [
+                    13.48451,
+                    52.6855
+                  ],
+                  [
+                    13.77993,
+                    52.43458
+                  ],
+                  [
+                    13.65355,
+                    52.33048
+                  ],
+                  [
+                    13.08165,
+                    52.38793
+                  ],
+                  [
+                    13.10821,
+                    52.58563
+                  ]
+                ]
+              ]
+            ]
+          },
+          "country_code": "DE"
+        },
+        {
+          "system_id":"example_paris",
+          "versions":[
+            {
+              "version": "2.0",
+              "url":"https://paris.example.com/gbfs/2/gbfs"
+            },
+            {
+              "version": "3.1-RC2",
+              "url":"https://paris.example.com/gbfs/3.1-RC2/gbfs"
+            }
+          ],
+          "area": {
+            "type": "MultiPolygon",
+            "coordinates": [
+              [
+                [
+                  [
+                    2.14306,
+                    48.89971
+                  ],
+                  [
+                    2.36707,
+                    48.99455
+                  ],
+                  [
+                    2.60219,
+                    49.01987
+                  ],
+                  [
+                    2.615,
+                    48.69025
+                  ],
+                  [
+                    2.52167,
+                    48.6867
+                  ],
+                  [
+                    2.26838,
+                    48.73275
+                  ],
+                  [
+                    2.13103,
+                    48.80833
+                  ],
+                  [
+                    2.14306,
+                    48.89971
+                  ]
+                ]
+              ]
+            ]
+          },
+          "country_code": "FR"
+        }
+      ]
+    }
+  }

--- a/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/station_information.json
+++ b/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/station_information.json
@@ -1,0 +1,31 @@
+{
+  "last_updated": "2023-07-17T13:34:13+02:00",
+  "ttl": 0,
+  "version": "3.1-RC2",
+  "data": {
+    "stations": [
+      {
+        "station_id": "pga",
+        "name": [
+          {
+            "text": "Parking garage A",
+            "language": "en"
+          }
+        ],
+        "lat": 12.345678,
+        "lon": 45.678901,
+        "station_opening_hours": "Su-Th 05:00-22:00; Fr-Sa 05:00-01:00",
+        "parking_type": "underground_parking",
+        "parking_hoop": false,
+        "contact_phone": "+33109874321",
+        "is_charging_station": true,
+        "vehicle_docks_capacity": [
+          {
+            "vehicle_type_ids": ["abc123"],
+            "count": 7
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/station_status.json
+++ b/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/station_status.json
@@ -1,0 +1,71 @@
+{
+  "last_updated": "2023-07-17T13:34:13+02:00",
+  "ttl": 0,
+  "version": "3.1-RC2",
+  "data": {
+    "stations": [
+      {
+        "station_id": "station1",
+        "is_installed": true,
+        "is_renting": true,
+        "is_returning": true,
+        "last_reported": "2023-07-17T13:34:13+02:00",
+        "num_docks_available": 3,
+        "num_docks_disabled" : 1,
+        "vehicle_docks_available": [
+          {
+            "vehicle_type_ids": [ "abc123", "def456" ],
+            "count": 2
+          },
+          {
+            "vehicle_type_ids": [ "def456" ],
+            "count": 1
+          }
+        ],
+        "num_vehicles_available": 1,
+        "num_vehicles_disabled": 2,
+        "vehicle_types_available": [
+          {
+            "vehicle_type_id": "abc123",
+            "count": 1
+          },
+          {
+            "vehicle_type_id": "def456",
+            "count": 0
+          }
+        ]
+      },
+      {
+        "station_id": "station2",
+        "is_installed": true,
+        "is_renting": true,
+        "is_returning": true,
+        "last_reported": "2023-07-17T13:34:13+02:00",
+        "num_docks_available": 8,
+        "num_docks_disabled" : 1,
+        "vehicle_docks_available": [
+          {
+            "vehicle_type_ids": [ "abc123" ],
+            "count": 6
+          },
+          {
+            "vehicle_type_ids": [ "def456" ],
+            "count": 2
+          }
+        ],
+        "num_vehicles_available": 6,
+        "num_vehicles_disabled": 1, 
+        "vehicle_types_available": [
+          {
+            "vehicle_type_id": "abc123",
+            "count": 2
+          },
+          {
+            "vehicle_type_id": "def456",
+            "count": 4
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/system_alerts.json
+++ b/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/system_alerts.json
@@ -1,0 +1,43 @@
+{
+    "last_updated": "2023-07-17T13:34:13+02:00",
+    "ttl": 60,
+    "version": "3.1-RC2",
+    "data": {
+      "alerts": [
+        {
+          "alert_id": "21",
+          "type": "station_closure",
+          "station_ids": [
+            "123",
+            "456",
+            "789"
+          ],
+          "times": [
+            {
+              "start": "2023-07-17T13:34:13+02:00",
+              "end": "2023-07-18T13:34:13+02:00"
+            }
+          ],
+          "url": [
+            {
+              "text": "https://example.com/more-info",
+              "language": "en"
+            }
+          ], 
+          "summary": [
+            {
+              "text": "Disruption of Service",
+              "language": "en"
+            }
+          ],
+          "description": [
+            {
+              "text": "The three stations on Broadway will be out of service from 12:00am Nov 3 to 3:00pm Nov 6th to accommodate road work",
+              "language": "en"
+            }
+          ],
+          "last_updated": "2023-07-17T13:34:13+02:00"
+        }
+      ]
+    }
+  }

--- a/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/system_information.json
+++ b/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/system_information.json
@@ -1,0 +1,68 @@
+{
+    "last_updated": "2023-07-17T13:34:13+02:00",
+    "ttl": 1800,
+    "version": "3.1-RC2",
+    "data": {
+      "system_id": "example_cityname",
+      "languages": ["en"],
+      "name": [
+        {
+          "text": "Example Bike Rental",
+          "language": "en"
+        }
+      ],
+      "short_name": [
+        {
+          "text": "Example Bike",
+          "language": "en"
+        }
+      ],
+      "operator": [
+        {
+          "text": "Example Sharing, Inc",
+          "language": "en"
+        }
+      ],
+      "opening_hours": "Apr 1-Nov 3 00:00-24:00",
+      "start_date": "2010-06-10",
+      "url": "https://www.example.com",
+      "purchase_url": "https://www.example.com",
+      "phone_number": "+18005551234",
+      "email": "customerservice@example.com",
+      "feed_contact_email": "datafeed@example.com",
+      "timezone": "America/Chicago",
+      "license_url": "https://www.example.com/data-license.html",
+      "terms_url": [
+        {
+           "text": "https://www.example.com/en/terms",
+           "language": "en"
+        }
+      ],
+      "terms_last_updated": "2021-06-21",
+      "privacy_url": [
+        {
+           "text": "https://www.example.com/en/privacy-policy",
+           "language": "en"
+        }
+      ],
+      "privacy_last_updated": "2019-01-13",
+      "rental_apps": {
+        "android": {
+          "discovery_uri": "com.example.android://",
+          "store_uri": "https://play.google.com/store/apps/details?id=com.example.android"
+        },
+        "ios": {
+          "store_uri": "https://apps.apple.com/app/apple-store/id123456789",
+          "discovery_uri": "com.example.ios://"
+        }
+      },
+      "brand_assets": {
+          "brand_last_modified": "2021-06-15",
+          "brand_image_url": "https://www.example.com/assets/brand_image.svg",
+          "brand_image_url_dark": "https://www.example.com/assets/brand_image_dark.svg",
+          "color": "#C2D32C",
+          "brand_terms_url": "https://www.example.com/assets/brand.pdf"
+        }
+        
+    }
+  }

--- a/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/system_pricing_plans.json
+++ b/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/system_pricing_plans.json
@@ -1,0 +1,46 @@
+{
+    "last_updated": "2023-07-17T13:34:13+02:00",
+    "ttl": 0,
+    "version": "3.1-RC2",
+    "data": {
+      "plans": [
+        {
+          "plan_id": "plan2",
+          "name": [
+            {
+              "text": "One-Way",
+              "language": "en"
+            }
+          ],
+          "currency": "USD",
+          "price": 2.00,
+          "reservation_price_per_min": 0.15,
+          "is_taxable": false,
+          "description": [
+            {
+              "text": "Includes 10km, overage fees apply after 10km.",
+              "language": "en"
+            }
+          ],
+          "per_km_pricing": [
+            {
+              "start": 10,
+              "rate": 1.00,
+              "interval": 1,
+              "end": 25
+            },
+            {
+              "start": 25,
+              "rate": 0.50,
+              "interval": 1
+            },
+            {
+              "start": 25,
+              "rate": 3.00,
+              "interval": 5
+            }
+          ]
+        }
+      ]
+    }
+  }

--- a/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/system_regions.json
+++ b/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/system_regions.json
@@ -1,0 +1,45 @@
+{
+    "last_updated": "2023-07-17T13:34:13+02:00",
+    "ttl": 86400,
+    "version": "3.1-RC2",
+    "data": {
+      "regions": [
+        {
+          "name": [
+            {
+              "text": "North",
+              "language": "en"
+            }
+          ],
+          "region_id": "3"
+        },
+        {
+          "name": [
+            {
+              "text": "East",
+              "language": "en"
+            }
+          ],
+          "region_id": "4"
+        },
+        {
+          "name": [
+            {
+              "text": "South",
+              "language": "en"
+            }
+          ],
+          "region_id": "5"
+        },
+        {
+          "name": [
+            {
+              "text": "West",
+              "language": "en"
+            }
+          ],
+          "region_id": "6"
+        }
+      ]
+    }
+  }

--- a/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/vehicle_availability.json
+++ b/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/vehicle_availability.json
@@ -1,0 +1,27 @@
+{
+  "last_updated": "2025-07-17T13:34:13+02:00",
+  "ttl": 0,
+  "version": "3.1-RC2",
+  "data": {
+    "vehicles": [
+      {
+        "vehicle_id": "vehicle_id_1",
+        "vehicle_type_id": "abc123",
+        "station_id": "pga",
+        "pricing_plan_id": "plan2",
+        "vehicle_equipment": [
+          "child_seat_a"
+        ],
+        "availabilities": [
+          {
+            "from": "2025-05-24T00:00:00+02:00",
+            "until": "2025-07-24T23:59:00+02:00"
+          },
+          {
+            "from": "2025-10-25T00:00:00+02:00"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/vehicle_status.json
+++ b/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/vehicle_status.json
@@ -1,0 +1,32 @@
+{
+  "last_updated": "2023-07-17T13:34:13+02:00",
+  "ttl":0,
+  "version": "3.1-RC2",
+  "data":{
+    "vehicles":[
+      {
+        "vehicle_id":"973a5c94-c288-4a2b-afa6-de8aeb6ae2e5",
+        "last_reported": "2023-07-17T13:34:13+02:00",
+        "lat":12.345678,
+        "lon":56.789012,
+        "is_reserved":false,
+        "is_disabled":false,
+        "vehicle_type_id":"abc123",
+        "rental_uris": {
+          "android": "https://www.example.com/app?vehicle_id=973a5c94-c288-4a2b-afa6-de8aeb6ae2e5&platform=android&",
+          "ios": "https://www.example.com/app?vehicle_id=973a5c94-c288-4a2b-afa6-de8aeb6ae2e5&platform=ios"
+        }
+      },
+      {
+        "vehicle_id":"987fd100-b822-4347-86a4-b3eef8ca8b53",
+        "last_reported": "2023-07-17T13:34:13+02:00",
+        "is_reserved":false,
+        "is_disabled":false,
+        "vehicle_type_id":"def456",
+        "current_range_meters":6543.0,
+        "station_id":"86",
+        "pricing_plan_id":"plan3"
+      }
+    ]
+  }
+}

--- a/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/vehicle_types.json
+++ b/models/java/gbfs-java-model/src/test/resources/v3_1_RC2/vehicle_types.json
@@ -1,0 +1,141 @@
+{
+  "last_updated": "2023-07-17T13:34:13+02:00",
+  "ttl": 0,
+  "version": "3.1-RC2",
+  "data": {
+    "vehicle_types": [
+      {
+        "vehicle_type_id": "abc123",
+        "form_factor": "bicycle",
+        "propulsion_type": "human",
+        "name": [
+          {
+            "text": "Example Basic Bike",
+            "language": "en"
+          }
+        ],
+        "wheel_count": 2,
+        "default_reserve_time": 30,
+        "return_constraint": "any_station",
+        "vehicle_assets": {
+          "icon_url": "https://www.example.com/assets/icon_bicycle.svg",
+          "icon_url_dark": "https://www.example.com/assets/icon_bicycle_dark.svg",
+          "icon_last_modified": "2021-06-15"
+        },
+        "default_pricing_plan_id": "bike_plan_1",
+        "pricing_plan_ids": [
+          "bike_plan_1",
+          "bike_plan_2",
+          "bike_plan_3"
+        ]
+      },
+      {
+        "vehicle_type_id": "cargo123",
+        "form_factor": "cargo_bicycle",
+        "propulsion_type": "human",
+        "name": [
+          {
+            "text": "Example Cargo Bike",
+            "language": "en"
+          }
+        ],
+        "description": [
+          {
+            "text": "Extra comfortable seat with additional suspension.\n\nPlease be aware of the cargo box lock: you need to press it down before pulling it up again!",
+            "language": "en"
+          }
+        ],            
+        "wheel_count": 3,
+        "default_reserve_time": 30,
+        "return_constraint": "roundtrip_station",
+        "vehicle_assets": {
+          "icon_url": "https://www.example.com/assets/icon_cargobicycle.svg",
+          "icon_url_dark": "https://www.example.com/assets/icon_cargobicycle_dark.svg",
+          "icon_last_modified": "2021-06-15"
+        },
+        "default_pricing_plan_id": "cargo_plan_1",
+        "pricing_plan_ids": [
+          "cargo_plan_1",
+          "cargo_plan_2",
+          "cargo_plan_3"
+        ]
+      },
+      {
+        "vehicle_type_id": "def456",
+        "form_factor": "scooter_standing",
+        "propulsion_type": "electric",
+        "name": [
+          {
+            "text": "Example E-scooter V2",
+            "language": "en"
+          }
+        ],
+        "wheel_count": 2,
+        "max_permitted_speed": 25,
+        "rated_power": 350,
+        "default_reserve_time": 30,
+        "max_range_meters": 12345,
+        "return_constraint": "free_floating",
+        "vehicle_assets": {
+          "icon_url": "https://www.example.com/assets/icon_escooter.svg",
+          "icon_url_dark": "https://www.example.com/assets/icon_escooter_dark.svg",
+          "icon_last_modified": "2021-06-15"
+        },
+        "default_pricing_plan_id": "scooter_plan_1"
+      },
+      {
+        "vehicle_type_id": "car1",
+        "form_factor": "car",
+        "rider_capacity": 5,
+        "cargo_volume_capacity": 200,
+        "propulsion_type": "combustion_diesel",
+        "eco_labels": [
+          {
+            "country_code": "FR",
+            "eco_sticker": "critair_1"
+          },
+          {
+            "country_code": "DE",
+            "eco_sticker": "euro_2"
+          }
+        ],
+        "name": [
+          {
+            "text": "Four-door Sedan",
+            "language": "en"
+          }
+        ],
+        "wheel_count": 4,
+        "default_reserve_time": 0,
+        "max_range_meters": 523992,
+        "return_constraint": "roundtrip_station",
+        "vehicle_accessories": [
+          "doors_4",
+          "automatic",
+          "cruise_control"
+        ],
+        "g_CO2_km": 120,
+        "vehicle_image": "https://www.example.com/assets/renault-clio.jpg",
+        "make": [
+          {
+            "text": "Renault",
+            "language": "en"
+          }
+        ],
+        "model": [
+          {
+            "text": "Clio",
+            "language": "en"
+          }
+        ],
+        "color": "white",
+        "vehicle_assets": {
+          "icon_url": "https://www.example.com/assets/icon_car.svg",
+          "icon_url_dark": "https://www.example.com/assets/icon_car_dark.svg",
+          "icon_last_modified": "2021-06-15"
+        },
+        "default_pricing_plan_id": "car_plan_1"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Included Java models for GBFS version 3.1-rc2. Included the test fixtures for 3.1-rc2 and corresponding tests