### PR TITLE
java deploy to central instead of oss

### DIFF
--- a/.github/workflows/build_deploy_java_language_bindings.yml
+++ b/.github/workflows/build_deploy_java_language_bindings.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - fix/174-java-deploy-central
     paths:
       - "models/java/**"
 
@@ -27,15 +28,15 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }} # This is required to connect to the vault in our 1Password account.
           MAVEN_GPG_PRIVATE_KEY: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/dkkfywvsr3xq6eyeubq6cldaxi/Private Key"
           MAVEN_GPG_PASSPHRASE: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/dkkfywvsr3xq6eyeubq6cldaxi/password"
-          MAVEN_USERNAME: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/4o43n5uyr7zjog6u2y5i3fjzye/username"
-          MAVEN_PASSWORD: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/4o43n5uyr7zjog6u2y5i3fjzye/credential"
+          MAVEN_USERNAME: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/Maven Central Portal user token/username"
+          MAVEN_PASSWORD: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/Maven Central Portal user token/password"
 
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           java-version: '17.0.11'
           distribution: 'temurin'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key:  ${{ env.MAVEN_GPG_PRIVATE_KEY }}

--- a/.github/workflows/build_deploy_java_language_bindings.yml
+++ b/.github/workflows/build_deploy_java_language_bindings.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - fix/174-java-deploy-central
     paths:
       - "models/java/**"
 

--- a/models/java/gbfs-java-model/pom.xml
+++ b/models/java/gbfs-java-model/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mobilitydata</groupId>
     <artifactId>gbfs-java-model</artifactId>
-    <version>1.0.11</version>
+    <version>1.0.12</version>
 
     <name>gbfs-java-model</name>
 

--- a/models/java/gbfs-java-model/pom.xml
+++ b/models/java/gbfs-java-model/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mobilitydata</groupId>
     <artifactId>gbfs-java-model</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
 
     <name>gbfs-java-model</name>
 
@@ -20,7 +20,7 @@
             <name>Apache License, Version 2.0</name>
             <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
-          </license>
+        </license>
     </licenses>
     <developers>
         <developer>
@@ -44,12 +44,12 @@
     </scm>
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/content/repositories/snapshots/</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 
@@ -61,7 +61,7 @@
         <jackson-databind.version>2.17.0</jackson-databind.version>
         <geojson-jackson.version>1.14</geojson-jackson.version>
 
-        <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <maven-exec-plugin.version>1.6.0</maven-exec-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
@@ -376,14 +376,13 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>${nexus-staging-maven-plugin.version}</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>${central-publishing-maven-plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
                 </configuration>
             </plugin>
             <plugin>
@@ -412,12 +411,12 @@
             </activation>
             <distributionManagement>
                 <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+                    <id>central</id>
+                    <url>https://central.sonatype.com/content/repositories/snapshots/</url>
                 </snapshotRepository>
                 <repository>
-                    <id>ossrh</id>
-                    <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
+                    <id>central</id>
+                    <url>https://central.sonatype.com/service/local/staging/deploy/maven2/</url>
                 </repository>
             </distributionManagement>
             <build>
@@ -434,7 +433,8 @@
                                     <goal>sign</goal>
                                 </goals>
                                 <configuration>
-                                    <!-- Prevent gpg from using pinentry programs. Fixes: gpg: signing
+                                    <!-- Prevent gpg from using pinentry programs. Fixes: gpg:
+                                    signing
                                         failed: Inappropriate ioctl for device -->
                                     <passphrase>${env.MAVEN_GPG_PASSPHRASE}</passphrase>
                                     <gpgArguments>
@@ -455,12 +455,12 @@
             </activation>
             <distributionManagement>
                 <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+                    <id>central</id>
+                    <url>https://central.sonatype.com/content/repositories/snapshots/</url>
                 </snapshotRepository>
                 <repository>
-                    <id>ossrh</id>
-                    <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
+                    <id>central</id>
+                    <url>https://central.sonatype.com/service/local/staging/deploy/maven2/</url>
                 </repository>
             </distributionManagement>
             <build>
@@ -487,14 +487,13 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://s01.oss.sonatype.org</nexusUrl>
-                            <!-- Set this to true and the release will automatically proceed and sync to Central Repository will follow  -->
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
closes #174 

Updates the deploy process for Java models from OSS to Central

Successful test deploy results for 1.0.11
<img width="1178" height="933" alt="image" src="https://github.com/user-attachments/assets/d6b8e03c-cdcc-43d0-972a-c9c30787df9d" />
