### PR TITLE
Remove deprecated scooter from form_factor enum in v3.0+

### DIFF
--- a/v3.0/vehicle_types.json
+++ b/v3.0/vehicle_types.json
@@ -42,7 +42,7 @@
               "form_factor": {
                 "description": "The vehicle's general form factor.",
                 "type": "string",
-                "enum": ["bicycle", "cargo_bicycle" ,"car", "moped", "scooter_standing", "scooter_seated", "other", "scooter"]
+                "enum": ["bicycle", "cargo_bicycle" ,"car", "moped", "scooter_standing", "scooter_seated", "other"]
               },
               "rider_capacity": {
                 "description": "The number of riders (driver included) the vehicle can legally accommodate",

--- a/v3.1-RC2/vehicle_types.json
+++ b/v3.1-RC2/vehicle_types.json
@@ -42,7 +42,7 @@
               "form_factor": {
                 "description": "The vehicle's general form factor.",
                 "type": "string",
-                "enum": ["bicycle", "cargo_bicycle" ,"car", "moped", "scooter_standing", "scooter_seated", "other", "scooter"]
+                "enum": ["bicycle", "cargo_bicycle" ,"car", "moped", "scooter_standing", "scooter_seated", "other"]
               },
               "rider_capacity": {
                 "description": "The number of riders (driver included) the vehicle can legally accommodate",


### PR DESCRIPTION
Removes the deprecated scooter value from the form_factor enum in v3.0 and v3.1-RC2.