### PR TITLE
Make vehicle_type_id optional in vehicle_availability.json

### DIFF
--- a/v3.1-RC2/vehicle_availability.json
+++ b/v3.1-RC2/vehicle_availability.json
@@ -75,7 +75,6 @@
             },
             "required": [
               "vehicle_id",
-              "vehicle_type_id",
               "station_id",
               "availabilities"
             ],


### PR DESCRIPTION
### Context
Follow up of https://github.com/MobilityData/gbfs/pull/845: `vehicle_type_id` became Conditionally REQUIRED in vehicle_availability.json.

### What's Changed
`vehicle_type_id` is now optional in the JSON schema of vehicle_availability.json.