### PR TITLE
release: v3.1-rc3

### DIFF
--- a/testFixtures/v3.1-RC3/gbfs.json
+++ b/testFixtures/v3.1-RC3/gbfs.json
@@ -1,7 +1,7 @@
 {
     "last_updated": "2023-07-17T13:34:13+02:00",
     "ttl": 0,
-    "version": "3.1-RC2",
+    "version": "3.1-RC3",
     "data": {
       "feeds": [
         {

--- a/testFixtures/v3.1-RC3/gbfs_versions.json
+++ b/testFixtures/v3.1-RC3/gbfs_versions.json
@@ -1,7 +1,7 @@
 {
     "last_updated": "2023-07-17T13:34:13+02:00",
     "ttl": 0,
-    "version": "3.1-RC2",
+    "version": "3.1-RC3",
     "data": {
       "versions": [
         {
@@ -9,8 +9,8 @@
           "url": "https://www.example.com/gbfs/2/gbfs"
         },
         {
-          "version": "3.1-RC2",
-          "url": "https://www.example.com/gbfs/3.1-RC2/gbfs"
+          "version": "3.1-RC3",
+          "url": "https://www.example.com/gbfs/3.1-RC3/gbfs"
         }
       ]
     }

--- a/testFixtures/v3.1-RC3/geofencing_zones.json
+++ b/testFixtures/v3.1-RC3/geofencing_zones.json
@@ -1,7 +1,7 @@
 {
     "last_updated": "2023-07-17T13:34:13+02:00",
     "ttl": 60,
-    "version": "3.1-RC2",
+    "version": "3.1-RC3",
     "data": {
       "geofencing_zones": {
         "type": "FeatureCollection",

--- a/testFixtures/v3.1-RC3/manifest.json
+++ b/testFixtures/v3.1-RC3/manifest.json
@@ -1,7 +1,7 @@
 {
     "last_updated": "2023-07-17T13:34:13+02:00",
     "ttl":0,
-    "version": "3.1-RC2",
+    "version": "3.1-RC3",
     "data":{
       "datasets":[
         {
@@ -12,8 +12,8 @@
               "url":"https://berlin.example.com/gbfs/2/gbfs"
             },
             {
-              "version": "3.1-RC2",
-              "url":"https://berlin.example.com/gbfs/3.1-RC2/gbfs"
+              "version": "3.1-RC3",
+              "url":"https://berlin.example.com/gbfs/3.1-RC3/gbfs"
             }
           ],
           "area": {
@@ -63,8 +63,8 @@
               "url":"https://paris.example.com/gbfs/2/gbfs"
             },
             {
-              "version": "3.1-RC2",
-              "url":"https://paris.example.com/gbfs/3.1-RC2/gbfs"
+              "version": "3.1-RC3",
+              "url":"https://paris.example.com/gbfs/3.1-RC3/gbfs"
             }
           ],
           "area": {

--- a/testFixtures/v3.1-RC3/station_information.json
+++ b/testFixtures/v3.1-RC3/station_information.json
@@ -1,7 +1,7 @@
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 0,
-  "version": "3.1-RC2",
+  "version": "3.1-RC3",
   "data": {
     "stations": [
       {

--- a/testFixtures/v3.1-RC3/station_status.json
+++ b/testFixtures/v3.1-RC3/station_status.json
@@ -1,7 +1,7 @@
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 0,
-  "version": "3.1-RC2",
+  "version": "3.1-RC3",
   "data": {
     "stations": [
       {

--- a/testFixtures/v3.1-RC3/system_alerts.json
+++ b/testFixtures/v3.1-RC3/system_alerts.json
@@ -1,7 +1,7 @@
 {
     "last_updated": "2023-07-17T13:34:13+02:00",
     "ttl": 60,
-    "version": "3.1-RC2",
+    "version": "3.1-RC3",
     "data": {
       "alerts": [
         {

--- a/testFixtures/v3.1-RC3/system_information.json
+++ b/testFixtures/v3.1-RC3/system_information.json
@@ -1,7 +1,7 @@
 {
     "last_updated": "2023-07-17T13:34:13+02:00",
     "ttl": 1800,
-    "version": "3.1-RC2",
+    "version": "3.1-RC3",
     "data": {
       "system_id": "example_cityname",
       "languages": ["en"],

--- a/testFixtures/v3.1-RC3/system_pricing_plans.json
+++ b/testFixtures/v3.1-RC3/system_pricing_plans.json
@@ -1,7 +1,7 @@
 {
     "last_updated": "2023-07-17T13:34:13+02:00",
     "ttl": 0,
-    "version": "3.1-RC2",
+    "version": "3.1-RC3",
     "data": {
       "plans": [
         {

--- a/testFixtures/v3.1-RC3/system_regions.json
+++ b/testFixtures/v3.1-RC3/system_regions.json
@@ -1,7 +1,7 @@
 {
     "last_updated": "2023-07-17T13:34:13+02:00",
     "ttl": 86400,
-    "version": "3.1-RC2",
+    "version": "3.1-RC3",
     "data": {
       "regions": [
         {

--- a/testFixtures/v3.1-RC3/vehicle_availability.json
+++ b/testFixtures/v3.1-RC3/vehicle_availability.json
@@ -1,7 +1,7 @@
 {
   "last_updated": "2025-07-17T13:34:13+02:00",
   "ttl": 0,
-  "version": "3.1-RC2",
+  "version": "3.1-RC3",
   "data": {
     "vehicles": [
       {

--- a/testFixtures/v3.1-RC3/vehicle_status.json
+++ b/testFixtures/v3.1-RC3/vehicle_status.json
@@ -1,7 +1,7 @@
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl":0,
-  "version": "3.1-RC2",
+  "version": "3.1-RC3",
   "data":{
     "vehicles":[
       {

--- a/testFixtures/v3.1-RC3/vehicle_types.json
+++ b/testFixtures/v3.1-RC3/vehicle_types.json
@@ -1,7 +1,7 @@
 {
   "last_updated": "2023-07-17T13:34:13+02:00",
   "ttl": 0,
-  "version": "3.1-RC2",
+  "version": "3.1-RC3",
   "data": {
     "vehicle_types": [
       {
@@ -17,6 +17,7 @@
         "wheel_count": 2,
         "default_reserve_time": 30,
         "return_constraint": "any_station",
+        "min_age": 14,
         "vehicle_assets": {
           "icon_url": "https://www.example.com/assets/icon_bicycle.svg",
           "icon_url_dark": "https://www.example.com/assets/icon_bicycle_dark.svg",
@@ -48,6 +49,7 @@
         "wheel_count": 3,
         "default_reserve_time": 30,
         "return_constraint": "roundtrip_station",
+        "min_age": 14,
         "vehicle_assets": {
           "icon_url": "https://www.example.com/assets/icon_cargobicycle.svg",
           "icon_url_dark": "https://www.example.com/assets/icon_cargobicycle_dark.svg",
@@ -76,6 +78,7 @@
         "default_reserve_time": 30,
         "max_range_meters": 12345,
         "return_constraint": "free_floating",
+        "min_age": 14,
         "vehicle_assets": {
           "icon_url": "https://www.example.com/assets/icon_escooter.svg",
           "icon_url_dark": "https://www.example.com/assets/icon_escooter_dark.svg",
@@ -129,6 +132,7 @@
           }
         ],
         "color": "white",
+        "min_age": 14,
         "vehicle_assets": {
           "icon_url": "https://www.example.com/assets/icon_car.svg",
           "icon_url_dark": "https://www.example.com/assets/icon_car_dark.svg",

--- a/v3.1-RC3/gbfs.json
+++ b/v3.1-RC3/gbfs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC2/gbfs.json",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC3/gbfs.json",
   "description": "Auto-discovery file that links to all of the other files published by the system.",
   "type": "object",
   "properties": {
@@ -17,7 +17,7 @@
     "version": {
       "description": "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.1-RC2"
+      "const": "3.1-RC3"
     },
     "data": {
       "type": "object",

--- a/v3.1-RC3/gbfs_versions.json
+++ b/v3.1-RC3/gbfs_versions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC2/gbfs_versions.json",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC3/gbfs_versions.json",
   "description": "Lists all feed endpoints published according to version sof the GBFS documentation. (added in v1.1)",
   "type": "object",
   "properties": {
@@ -17,7 +17,7 @@
     "version": {
       "description": "GBFS version number to which the feed conforms, according to the versioning framework.",
       "type": "string",
-      "const": "3.1-RC2"
+      "const": "3.1-RC3"
     },
     "data": {
       "description": "Response data in the form of name:value pairs.",
@@ -40,7 +40,7 @@
                   "2.2",
                   "2.3",
                   "3.0",
-                  "3.1-RC2"
+                  "3.1-RC3"
                 ]
               },
               "url": {

--- a/v3.1-RC3/geofencing_zones.json
+++ b/v3.1-RC3/geofencing_zones.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC2/geofencing_zones.json",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC3/geofencing_zones.json",
   "description": "Describes geofencing zones and their associated rules and attributes (added in v2.1-RC).",
   "type": "object",
   "properties": {
@@ -17,7 +17,7 @@
     "version": {
       "description": "GBFS version number to which the feed conforms, according to the versioning framework.",
       "type": "string",
-      "const": "3.1-RC2"
+      "const": "3.1-RC3"
     },
     "data": {
       "description": "Array that contains geofencing information for the system.",

--- a/v3.1-RC3/manifest.json
+++ b/v3.1-RC3/manifest.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC2/manifest.json",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC3/manifest.json",
   "description": "An index of gbfs.json URLs for each GBFS data set produced by a publisher. A single instance of this file should be published at a single stable URL, for example: https://example.com/gbfs/manifest.json.",
   "type": "object",
   "properties": {
@@ -17,7 +17,7 @@
     "version": {
       "description": "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.1-RC2"
+      "const": "3.1-RC3"
     },
     "data": {
       "type": "object",
@@ -49,7 +49,7 @@
                         "2.2",
                         "2.3",
                         "3.0",
-                        "3.1-RC2"
+                        "3.1-RC3"
                       ]
                     },
                     "url": {

--- a/v3.1-RC3/station_information.json
+++ b/v3.1-RC3/station_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC2/station_information.json",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC3/station_information.json",
   "description":
     "List of all stations, their capacities and locations. REQUIRED of systems utilizing docks.",
   "type": "object",
@@ -22,7 +22,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.1-RC2"
+      "const": "3.1-RC3"
     },
     "data": {
       "description":
@@ -107,7 +107,7 @@
                 "type": "string"
               },
               "city": {
-                "description": "City where station is located. (added in v3.1-RC2)",
+                "description": "City where station is located. (added in v3.1-RC3)",
                 "type": "string"
               },
               "station_opening_hours": {

--- a/v3.1-RC3/station_status.json
+++ b/v3.1-RC3/station_status.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC2/station_status.json",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC3/station_status.json",
   "description":
     "Describes the capacity and rental availability of the station",
   "type": "object",
@@ -21,7 +21,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.1-RC2"
+      "const": "3.1-RC3"
     },
     "data": {
       "description":

--- a/v3.1-RC3/system_alerts.json
+++ b/v3.1-RC3/system_alerts.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC2/system_alerts.json",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC3/system_alerts.json",
   "description": "Describes ad-hoc changes to the system.",
   "type": "object",
   "properties": {
@@ -20,7 +20,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.1-RC2"
+      "const": "3.1-RC3"
     },
     "data": {
       "description": "Array that contains ad-hoc alerts for the system.",

--- a/v3.1-RC3/system_information.json
+++ b/v3.1-RC3/system_information.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC2/system_information.json",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC3/system_information.json",
   "description":
     "Details including system operator, system location, year implemented, URL, contact info, time zone.",
   "type": "object",
@@ -22,7 +22,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.1-RC2"
+      "const": "3.1-RC3"
     },
     "data": {
       "description": "Response data in the form of name:value pairs.",

--- a/v3.1-RC3/system_pricing_plans.json
+++ b/v3.1-RC3/system_pricing_plans.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC2/system_pricing_plans.json",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC3/system_pricing_plans.json",
   "description": "Describes the pricing schemes of the system.",
   "type": "object",
   "properties": {
@@ -21,7 +21,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.1-RC2"
+      "const": "3.1-RC3"
     },
     "data": {
       "description":
@@ -183,7 +183,7 @@
               },
               "fare_capping": {
                 "type": "object",
-                "description": "Object defining a capped fare once a price threshold has been spent within a timeframe. (added in v3.1-RC2)",
+                "description": "Object defining a capped fare once a price threshold has been spent within a timeframe. (added in v3.1-RC3)",
                 "properties": {
                   "duration": {
                     "description": "Amount of time in minutes during which the fare is capped.",

--- a/v3.1-RC3/system_regions.json
+++ b/v3.1-RC3/system_regions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC2/system_regions.json",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC3/system_regions.json",
   "description":
     "Describes regions for a system that is broken up by geographic or political region.",
   "type": "object",
@@ -21,7 +21,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.1-RC2"
+      "const": "3.1-RC3"
     },
     "data": {
       "description": "Describe regions for a system that is broken up by geographic or political region.",

--- a/v3.1-RC3/vehicle_availability.json
+++ b/v3.1-RC3/vehicle_availability.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC2/vehicle_availability.json",
+  "$id": "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC3/vehicle_availability.json",
   "description": "Describes the vehicle availabilities of the system.",
   "type": "object",
   "properties": {
@@ -17,7 +17,7 @@
     "version": {
       "description": "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.1-RC2"
+      "const": "3.1-RC3"
     },
     "data": {
       "type": "object",

--- a/v3.1-RC3/vehicle_status.json
+++ b/v3.1-RC3/vehicle_status.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC2/vehicle_status.json",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC3/vehicle_status.json",
   "description":
     "Describes the vehicles that are available for rent (as of v3.0, formerly free_bike_status).",
   "type": "object",
@@ -22,7 +22,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework (added in v1.1).",
       "type": "string",
-      "const": "3.1-RC2"
+      "const": "3.1-RC3"
     },
     "data": {
       "description":

--- a/v3.1-RC3/vehicle_types.json
+++ b/v3.1-RC3/vehicle_types.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id":
-    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC2/vehicle_types.json",
+    "https://github.com/MobilityData/gbfs-json-schema/blob/master/v3.1-RC3/vehicle_types.json",
   "description":
     "Describes the types of vehicles that System operator has available for rent (added in v2.1-RC).",
   "type": "object",
@@ -22,7 +22,7 @@
       "description":
         "GBFS version number to which the feed conforms, according to the versioning framework.",
       "type": "string",
-      "const": "3.1-RC2"
+      "const": "3.1-RC3"
     },
     "data": {
       "description": "Response data in the form of name:value pairs.",
@@ -211,6 +211,11 @@
                 "description": "The conditions for returning the vehicle at the end of the trip. Added in v2.3-RC as return_type, and updated to return_constraint in v2.3.",
                 "type": "string",
                 "enum": ["free_floating", "roundtrip_station", "any_station", "hybrid"]
+              },
+              "min_age": {
+                "description": "Minimum age required to use this vehicle. Added in v3.1-RC3.",
+                "type": "integer",
+                "minimum": 0
               },
               "vehicle_assets": {
                 "description": "An object where each key defines one of the items listed below added in v2.3-RC.",


### PR DESCRIPTION
closes #192 

Changes
- Renamed 3.1-RC2 to 3.1-RC3
- Added the min_age property
- Updated the test fixtures

changes done based on 
https://github.com/MobilityData/gbfs/pull/867