### PR TITLE
vehicle availability to gbfs feed names (java)

### DIFF
--- a/models/java/gbfs-java-model/pom.xml
+++ b/models/java/gbfs-java-model/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mobilitydata</groupId>
     <artifactId>gbfs-java-model</artifactId>
-    <version>1.0.13</version>
+    <version>1.0.14</version>
 
     <name>gbfs-java-model</name>
 

--- a/models/java/gbfs-java-model/src/main/java/org/mobilitydata/gbfs/v3_1_RC3/gbfs/GBFSFeedName.java
+++ b/models/java/gbfs-java-model/src/main/java/org/mobilitydata/gbfs/v3_1_RC3/gbfs/GBFSFeedName.java
@@ -8,6 +8,7 @@ import org.mobilitydata.gbfs.v3_1_RC3.system_alerts.GBFSSystemAlerts;
 import org.mobilitydata.gbfs.v3_1_RC3.system_information.GBFSSystemInformation;
 import org.mobilitydata.gbfs.v3_1_RC3.system_pricing_plans.GBFSSystemPricingPlans;
 import org.mobilitydata.gbfs.v3_1_RC3.system_regions.GBFSSystemRegions;
+import org.mobilitydata.gbfs.v3_1_RC3.vehicle_availability.GBFSVehicleAvailability;
 import org.mobilitydata.gbfs.v3_1_RC3.vehicle_status.GBFSVehicleStatus;
 import org.mobilitydata.gbfs.v3_1_RC3.vehicle_types.GBFSVehicleTypes;
 
@@ -33,6 +34,7 @@ public class GBFSFeedName {
         feedNameMap.put(GBFSFeed.Name.SYSTEM_INFORMATION, GBFSSystemInformation.class);
         feedNameMap.put(GBFSFeed.Name.SYSTEM_PRICING_PLANS, GBFSSystemPricingPlans.class);
         feedNameMap.put(GBFSFeed.Name.SYSTEM_REGIONS, GBFSSystemRegions.class);
+        feedNameMap.put(GBFSFeed.Name.VEHICLE_AVAILABILITY, GBFSVehicleAvailability.class);
         feedNameMap.put(GBFSFeed.Name.VEHICLE_STATUS, GBFSVehicleStatus.class);
         feedNameMap.put(GBFSFeed.Name.VEHICLE_TYPES, GBFSVehicleTypes.class);
         classMap = feedNameMap.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));


### PR DESCRIPTION
Adds VEHICLE_AVAILABILITY feed file to the map GBFSFeedName. 
We use the GBFSFeedName class of the library to get the implementation class of a feed name. 
The VEHICLE_AVAILABILITY file of 3.1 is not supported yet.