### PR TITLE
fix: update rust publish workflow

### DIFF
--- a/.github/workflows/rust_crate_publish.yml
+++ b/.github/workflows/rust_crate_publish.yml
@@ -29,5 +29,5 @@ jobs:
             - name: Publish to crates.io
               env:
                 CARGO_REGISTRY_TOKEN: ${{ env.CARGO_REGISTRY_TOKEN }}
-              run: cargo publish --token $CARGO_REGISTRY_TOKEN
+              run: cargo publish
                 

--- a/models/rust/Cargo.lock
+++ b/models/rust/Cargo.lock
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "gbfs_types"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "futures",
  "geo-types",

--- a/models/rust/Cargo.toml
+++ b/models/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gbfs_types"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "Apache-2.0"
 description = "Types for GBFS"


### PR DESCRIPTION
When publishing the rust package `cargo publish --token $CARGO_REGISTRY_TOKEN` has become deprecated. No longer needed to specify the token, it will pick it up based on the environment automatically

Also update the rust version for the package