### PR TITLE
Validate conditional presence of station/vehicle feeds in gbfs.json

### DIFF
--- a/testFixtures/v3.1-RC3/gbfs.json
+++ b/testFixtures/v3.1-RC3/gbfs.json
@@ -11,6 +11,10 @@
         {
           "name": "station_information",
           "url": "https://www.example.com/gbfs/1/station_information"
+        },
+        {
+          "name": "station_status",
+          "url": "https://www.example.com/gbfs/1/station_status"
         }
       ]
     }

--- a/v2.0/gbfs.json
+++ b/v2.0/gbfs.json
@@ -68,7 +68,43 @@
                 "properties": {
                   "name": { "const": "system_information" }
                 }
-              }
+              },
+              "allOf": [
+                {
+                  "anyOf": [
+                    {
+                      "contains": {
+                        "properties": {
+                          "name": { "const": "station_status" }
+                        }
+                      }
+                    },
+                    {
+                      "contains": {
+                        "properties": {
+                          "name": { "const": "free_bike_status" }
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "if": {
+                    "contains": {
+                      "properties": {
+                        "name": { "const": "station_information" }
+                      }
+                    }
+                  },
+                  "then": {
+                    "contains": {
+                      "properties": {
+                        "name": { "const": "station_status" }
+                      }
+                    }
+                  }
+                }
+              ]
             }
           },
           "required": ["feeds"]

--- a/v2.1/gbfs.json
+++ b/v2.1/gbfs.json
@@ -70,7 +70,43 @@
                 "properties": {
                   "name": { "const": "system_information" }
                 }
-              }
+              },
+              "allOf": [
+                {
+                  "anyOf": [
+                    {
+                      "contains": {
+                        "properties": {
+                          "name": { "const": "station_status" }
+                        }
+                      }
+                    },
+                    {
+                      "contains": {
+                        "properties": {
+                          "name": { "const": "free_bike_status" }
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "if": {
+                    "contains": {
+                      "properties": {
+                        "name": { "const": "station_information" }
+                      }
+                    }
+                  },
+                  "then": {
+                    "contains": {
+                      "properties": {
+                        "name": { "const": "station_status" }
+                      }
+                    }
+                  }
+                }
+              ]
             }
           },
           "required": ["feeds"]

--- a/v2.2/gbfs.json
+++ b/v2.2/gbfs.json
@@ -70,7 +70,43 @@
                 "properties": {
                   "name": { "const": "system_information" }
                 }
-              }
+              },
+              "allOf": [
+                {
+                  "anyOf": [
+                    {
+                      "contains": {
+                        "properties": {
+                          "name": { "const": "station_status" }
+                        }
+                      }
+                    },
+                    {
+                      "contains": {
+                        "properties": {
+                          "name": { "const": "free_bike_status" }
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "if": {
+                    "contains": {
+                      "properties": {
+                        "name": { "const": "station_information" }
+                      }
+                    }
+                  },
+                  "then": {
+                    "contains": {
+                      "properties": {
+                        "name": { "const": "station_status" }
+                      }
+                    }
+                  }
+                }
+              ]
             }
           },
           "required": ["feeds"]

--- a/v2.3/gbfs.json
+++ b/v2.3/gbfs.json
@@ -70,7 +70,43 @@
                 "properties": {
                   "name": { "const": "system_information" }
                 }
-              }
+              },
+              "allOf": [
+                {
+                  "anyOf": [
+                    {
+                      "contains": {
+                        "properties": {
+                          "name": { "const": "station_status" }
+                        }
+                      }
+                    },
+                    {
+                      "contains": {
+                        "properties": {
+                          "name": { "const": "free_bike_status" }
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "if": {
+                    "contains": {
+                      "properties": {
+                        "name": { "const": "station_information" }
+                      }
+                    }
+                  },
+                  "then": {
+                    "contains": {
+                      "properties": {
+                        "name": { "const": "station_status" }
+                      }
+                    }
+                  }
+                }
+              ]
             }
           },
           "required": ["feeds"]

--- a/v3.0/gbfs.json
+++ b/v3.0/gbfs.json
@@ -58,7 +58,43 @@
             "properties": {
               "name": { "const": "system_information" }
             }
-          }
+          },
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "contains": {
+                    "properties": {
+                      "name": { "const": "station_status" }
+                    }
+                  }
+                },
+                {
+                  "contains": {
+                    "properties": {
+                      "name": { "const": "vehicle_status" }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "if": {
+                "contains": {
+                  "properties": {
+                    "name": { "const": "station_information" }
+                  }
+                }
+              },
+              "then": {
+                "contains": {
+                  "properties": {
+                    "name": { "const": "station_status" }
+                  }
+                }
+              }
+            }
+          ]
         }
       },
       "required": ["feeds"]

--- a/v3.1-RC3/gbfs.json
+++ b/v3.1-RC3/gbfs.json
@@ -59,7 +59,43 @@
             "properties": {
               "name": { "const": "system_information" }
             }
-          }
+          },
+          "allOf": [
+            {
+              "anyOf": [
+                {
+                  "contains": {
+                    "properties": {
+                      "name": { "const": "station_status" }
+                    }
+                  }
+                },
+                {
+                  "contains": {
+                    "properties": {
+                      "name": { "const": "vehicle_status" }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "if": {
+                "contains": {
+                  "properties": {
+                    "name": { "const": "station_information" }
+                  }
+                }
+              },
+              "then": {
+                "contains": {
+                  "properties": {
+                    "name": { "const": "station_status" }
+                  }
+                }
+              }
+            }
+          ]
         }
       },
       "required": ["feeds"]


### PR DESCRIPTION
Closes #180

## What

Adds two conditional feed-presence rules to the `gbfs.json` `feeds` array, as an `allOf` sibling of the existing `system_information` `contains` constraint, using draft-07 `contains` + `anyOf`/`if`/`then`:

1. **At least one mode** — `feeds` MUST contain at least one of `station_status` **or** the free-floating feed (`vehicle_status` in v3.x, `free_bike_status` in v2.x).
2. **Station pairing** — IF `station_information` is declared, `station_status` MUST also be declared.

Applied to **v2.0, v2.1, v2.2, v2.3, v3.0, v3.1-RC3**.

## Notes

- The added keywords are **validation-only**. Verified that the committed **Go** model regenerates byte-identical, and the **Java** (jsonschema2pojo) and **TypeScript** (quicktype) builds + tests pass unchanged — so no model regeneration is required.
- `testFixtures/v3.1-RC3/gbfs.json` declared `station_information` without `station_status` (now invalid under rule 2, and consumed by the TypeScript test) and gains the missing `station_status` entry.

## Verification

- 30-case validation harness (valid/invalid instances × 6 versions) — all pass
- All 6 schemas valid draft-07
- Fixed fixture validates against its schema
- Java model build: 67 tests, 0 failures · TypeScript: 38 tests pass · Go model: regenerates byte-identical